### PR TITLE
Refactor grid item styles

### DIFF
--- a/script.js
+++ b/script.js
@@ -535,25 +535,13 @@ function createItemImageElement(item, width, height, isGhost = false) {
     img.src = item.img;
     img.alt = item.nome;
     img.className = 'grid-item-img';
-    img.style.position = 'absolute';
-    img.style.left = '0';
-    img.style.top = '0';
-    img.style.objectFit = 'contain';
-    img.style.pointerEvents = 'none';
-    img.style.zIndex = '10';
-    img.style.transition = 'transform 0.2s';
-    if (isGhost) {
-        img.style.width = '100%';
-        img.style.height = '100%';
-        if (previewRotation) {
-            img.style.transform = 'rotate(90deg)';
-        }
-    } else {
-        img.style.width = ((CELL_SIZE + CELL_GAP) * width - CELL_GAP) + 'px';
-        img.style.height = ((CELL_SIZE + CELL_GAP) * height - CELL_GAP) + 'px';
+    if (!isGhost) {
+        img.classList.add(`w${width}`, `h${height}`);
         if (item.rotacionado) {
-            img.style.transform = 'rotate(90deg)';
+            img.classList.add('rotacionado');
         }
+    } else if (previewRotation) {
+        img.classList.add('rotacionado');
     }
     return img;
 }

--- a/style.css
+++ b/style.css
@@ -118,6 +118,25 @@ body {
     border-radius: 7px;
     transition: transform 0.2s;
 }
+.rotacionado {
+    transform: rotate(90deg);
+}
+.w1 { width: 40px; }
+.w2 { width: 83px; }
+.w3 { width: 126px; }
+.w4 { width: 169px; }
+.w5 { width: 212px; }
+.w6 { width: 255px; }
+.w7 { width: 298px; }
+.w8 { width: 341px; }
+.w9 { width: 384px; }
+.w10 { width: 427px; }
+.h1 { height: 40px; }
+.h2 { height: 83px; }
+.h3 { height: 126px; }
+.h4 { height: 169px; }
+.h5 { height: 212px; }
+.h6 { height: 255px; }
 .cell.has-img {
     position: relative;
     overflow: visible;


### PR DESCRIPTION
## Summary
- avoid inline styles when creating item images
- add CSS classes for grid item sizing and rotation

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68643a9e15d08320a39e8ad4621a08b5