### PR TITLE
Implement registration with security question

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ fetch('users.json')
   .then(r => r.json())
   .then(data => localStorage.setItem('tetris-users', JSON.stringify(data)));
 ```
+
+### Registro de usuários
+
+Quando não houver nenhum cadastro, o primeiro usuário criado será o
+**Mestre**. O registro solicita nome, senha e uma pergunta de segurança com a
+resposta correspondente. Se já existir um mestre, os próximos registros serão
+considerados jogadores.
 ---
 
 ## 🌐 Acesse Online

--- a/login.js
+++ b/login.js
@@ -15,11 +15,17 @@ function saveUsers(users) {
     localStorage.setItem('tetris-users', JSON.stringify(users));
 }
 
-export async function registerUser(userName, password, isMaster = false) {
+export async function registerUser(userName, password, isMaster = false, pergunta = '', resposta = '') {
     const users = getUsers();
     if (users[userName]) return false;
     const hash = await sha256(password);
-    users[userName] = { hash, isMaster };
+    const userData = { hash, isMaster };
+    if (pergunta && resposta) {
+        const respostaHash = await sha256(resposta);
+        userData.pergunta = pergunta;
+        userData.respostaHash = respostaHash;
+    }
+    users[userName] = userData;
     saveUsers(users);
     return true;
 }
@@ -79,7 +85,17 @@ export function setupLogin() {
         const users = getUsers();
         if (!users[user]) {
             const isFirst = Object.keys(users).length === 0;
-            await registerUser(user, pass, isFirst);
+            const pergunta = prompt('Pergunta de seguran\u00e7a:');
+            if (!pergunta) {
+                loginErr.textContent = 'Pergunta obrigat\u00f3ria para registro';
+                return;
+            }
+            const resposta = prompt('Resposta para a pergunta:');
+            if (!resposta) {
+                loginErr.textContent = 'Resposta obrigat\u00f3ria para registro';
+                return;
+            }
+            await registerUser(user, pass, isFirst, pergunta, resposta);
         }
         const ok = await validateLogin(user, pass);
         if (!ok) {


### PR DESCRIPTION
## Summary
- ask for security question when creating new users
- store question and hashed answer during registration
- document new registration flow in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6864474b81cc8320a7af87edbb550038