### PR TITLE
Improve responsive grid layout

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -3,12 +3,17 @@ export const COLS = 10;
 export const CELL_SIZE = 40; // tamanho base em px
 export const CELL_GAP = 3;  // espaçamento em px
 
+export function getCellSize() {
+    const value = getComputedStyle(document.documentElement).getPropertyValue('--cell-size');
+    return parseFloat(value);
+}
+
 export function applyLayoutSettings() {
     const root = document.documentElement;
     root.style.setProperty('--rows', ROWS);
     root.style.setProperty('--cols', COLS);
-    root.style.setProperty('--cell-size', `${CELL_SIZE}px`);
-    root.style.setProperty('--cell-gap', `${CELL_GAP}px`);
+    root.style.setProperty('--cell-size', `${CELL_SIZE / 16}rem`);
+    root.style.setProperty('--cell-gap', `${CELL_GAP / 16}rem`);
 
     const widthInput = document.getElementById('largura');
     const heightInput = document.getElementById('altura');

--- a/dragdrop.js
+++ b/dragdrop.js
@@ -1,6 +1,6 @@
 import { inventory, itemList, clearGridSelection, removeItemFromGrid, clearCells, canPlace, placeItem, createItemImageElement, returnItemToPanel, removeItemFromPanel, getInventoryState, setInventoryState, updateItemList } from './inventory.js';
 import { saveInventory } from './storage.js';
-import { ROWS, COLS, CELL_SIZE, CELL_GAP } from './constants.js';
+import { ROWS, COLS, CELL_GAP, getCellSize } from './constants.js';
 
 const dragGhost = document.getElementById('drag-ghost');
 
@@ -127,7 +127,7 @@ function computeGridPosition(pageX, pageY) {
     const invRect = inventory.getBoundingClientRect();
     const relX = pageX - invRect.left;
     const relY = pageY - invRect.top;
-    const total = CELL_SIZE + CELL_GAP;
+    const total = getCellSize() + CELL_GAP;
     let gridX = Math.floor(relX / total);
     let gridY = Math.floor(relY / total);
     if (gridX < 0) gridX = 0;
@@ -146,7 +146,7 @@ function snapGhostToGrid(pageX, pageY) {
 function showGhostOnGrid(gridX, gridY) {
     const valid = canPlace(gridX, gridY, currentPreviewSize.width, currentPreviewSize.height);
     dragGhost.innerHTML = '';
-    const total = CELL_SIZE + CELL_GAP;
+    const total = getCellSize() + CELL_GAP;
     dragGhost.style.width = (currentPreviewSize.width * total - CELL_GAP) + 'px';
     dragGhost.style.height = (currentPreviewSize.height * total - CELL_GAP) + 'px';
     dragGhost.style.display = 'block';

--- a/style.css
+++ b/style.css
@@ -2,8 +2,8 @@
 :root {
     --cols: 10;
     --rows: 6;
-    --cell-size: 40px;
-    --cell-gap: 3px;
+    --cell-size: 2.5rem;
+    --cell-gap: 0.1875rem;
 }
 
 body {
@@ -14,19 +14,19 @@ body {
 
 #inventory {
     display: grid;
-    grid-template-columns: repeat(var(--cols), var(--cell-size));
+    grid-template-columns: repeat(var(--cols), 1fr);
     grid-template-rows: repeat(var(--rows), var(--cell-size));
     gap: var(--cell-gap);
     background: #333;
     padding: 10px;
     margin-bottom: 20px;
-    width: fit-content;
+    width: calc(var(--cols) * var(--cell-size) + (var(--cols) - 1) * var(--cell-gap));
     max-width: 100%;
 }
 
 .cell {
-    width: var(--cell-size);
-    height: var(--cell-size);
+    width: 100%;
+    height: 100%;
     background: #eee;
     border: 1px solid #ccc;
     box-sizing: border-box;
@@ -107,8 +107,8 @@ body {
 }
 
 .item-img {
-    width: 28px;
-    height: 28px;
+    width: 1.75rem;
+    height: 1.75rem;
     object-fit: cover;
     margin-right: 6px;
     vertical-align: middle;
@@ -158,7 +158,7 @@ body {
 
 @media (max-width: 600px) {
     :root {
-        --cell-size: 30px;
+        --cell-size: 1.875rem;
     }
     #item-form {
         max-width: 100%;


### PR DESCRIPTION
## Summary
- use `rem` units for layout CSS variables
- compute cell size from CSS for drag operations
- adapt ghost helper to dynamic size
- tweak item image sizing
- adjust small-screen cell size via media query

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68644a745c508320b14757047fa7443a