### PR TITLE
Fix missing drag handlers for newly created items

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,5 +10,8 @@ window.addEventListener('DOMContentLoaded', () => {
     initInventory();
     registerPanelDragHandlers();
     initDragDrop();
-    form.addEventListener('submit', handleItemSubmit);
+    form.addEventListener('submit', async (e) => {
+        await handleItemSubmit(e);
+        registerPanelDragHandlers();
+    });
 });


### PR DESCRIPTION
## Summary
- re-register drag handlers after creating a new item

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6864530d45648320913c41ba0056ab80