### PR TITLE
Add customizable item color and centered layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
             <input type="number" id="altura" placeholder="Altura" min="1" required>
             <label for="imagem">Imagem</label>
             <input type="file" id="imagem" accept="image/*">
+            <label for="cor">Cor do item</label>
+            <input type="color" id="cor" value="#2b8a3e">
             <button type="submit">Adicionar</button>
         </form>
     </div>

--- a/inventory.js
+++ b/inventory.js
@@ -8,9 +8,9 @@ export const form = document.getElementById('item-form');
 export const itemsPanel = document.getElementById('items');
 
 let itemsData = [
-    { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null },
-    { id: generateId(), nome: 'Lança', width: 1, height: 3, img: null },
-    { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null },
+    { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null, color: '#2b8a3e' },
+    { id: generateId(), nome: 'Lança', width: 1, height: 3, img: null, color: '#2b8a3e' },
+    { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null, color: '#2b8a3e' },
 ];
 let placedItems = [];
 
@@ -53,6 +53,7 @@ export function updateItemList() {
         el.dataset.idx = idx;
         el.dataset.width = item.width;
         el.dataset.height = item.height;
+        el.style.borderColor = item.color;
         if (item.img) {
             const img = document.createElement('img');
             img.src = item.img;
@@ -73,8 +74,9 @@ export function getItemFormData() {
     const width = parseInt(document.getElementById('largura').value);
     const height = parseInt(document.getElementById('altura').value);
     const imgInput = document.getElementById('imagem');
+    const color = document.getElementById('cor').value || '#2b8a3e';
     if (!nome || width < 1 || height < 1 || width > COLS || height > ROWS) return null;
-    return { nome, width, height, imgInput };
+    return { nome, width, height, imgInput, color };
 }
 
 export function addNewItem(data) {
@@ -83,7 +85,8 @@ export function addNewItem(data) {
         nome: data.nome,
         width: data.width,
         height: data.height,
-        img: data.img
+        img: data.img,
+        color: data.color
     });
     updateItemList();
     saveInventory(itemsData, placedItems);
@@ -101,7 +104,8 @@ export function returnItemToPanel(item) {
         nome: item.nome,
         width: item.originalWidth ?? item.width,
         height: item.originalHeight ?? item.height,
-        img: item.img || null
+        img: item.img || null,
+        color: item.color
     });
     updateItemList();
     saveInventory(itemsData, placedItems);
@@ -185,7 +189,14 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             cell.classList.add('placed');
             cell.dataset.itemid = item.id;
             cell.title = item.nome || '';
-            if (dx === 0 && dy === 0) {
+            if (!item.img) {
+                cell.style.background = item.color;
+                cell.style.border = `2px solid ${item.color}`;
+                if (dx > 0) cell.style.borderLeft = '0';
+                if (dy > 0) cell.style.borderTop = '0';
+                if (dx < w - 1) cell.style.borderRight = '0';
+                if (dy < h - 1) cell.style.borderBottom = '0';
+            } else if (dx === 0 && dy === 0) {
                 removeGridImage(cell);
             }
         }
@@ -207,6 +218,7 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             height: h,
             rotacionado: item.rotacionado,
             img: item.img || null,
+            color: item.color,
             originalWidth: item.originalWidth ?? (item.rotacionado ? item.height : item.width),
             originalHeight: item.originalHeight ?? (item.rotacionado ? item.width : item.height)
         });
@@ -219,6 +231,7 @@ export function createItemImageElement(item, width, height, isGhost = false) {
     img.src = item.img;
     img.alt = item.nome;
     img.className = 'grid-item-img';
+    img.style.border = `2px solid ${item.color}`;
     if (!isGhost) {
         img.classList.add(`w${width}`, `h${height}`);
         if (item.rotacionado) {
@@ -240,6 +253,12 @@ export function resetCell(cell) {
     cell.classList.remove('placed', 'selected');
     delete cell.dataset.itemid;
     cell.title = '';
+    cell.style.border = '';
+    cell.style.borderLeft = '';
+    cell.style.borderTop = '';
+    cell.style.borderRight = '';
+    cell.style.borderBottom = '';
+    cell.style.background = '';
     removeGridImage(cell);
 }
 

--- a/storage.js
+++ b/storage.js
@@ -7,9 +7,9 @@ function generateId() {
 
 function defaultItems() {
     return [
-        { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null },
-        { id: generateId(), nome: 'Lan\u00e7a', width: 1, height: 3, img: null },
-        { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null }
+        { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null, color: '#2b8a3e' },
+        { id: generateId(), nome: 'Lan\u00e7a', width: 1, height: 3, img: null, color: '#2b8a3e' },
+        { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null, color: '#2b8a3e' }
     ];
 }
 
@@ -27,7 +27,8 @@ function sanitizeItems(items) {
             nome: it.nome,
             width,
             height,
-            img: it.img || null
+            img: it.img || null,
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e'
         });
     }
     return valid.length ? valid : defaultItems();
@@ -54,6 +55,7 @@ function sanitizePlaced(items) {
             height,
             rotacionado: !!it.rotacionado,
             img: it.img || null,
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e',
             originalWidth: it.originalWidth ?? width,
             originalHeight: it.originalHeight ?? height
         });

--- a/style.css
+++ b/style.css
@@ -8,8 +8,13 @@
 
 body {
     font-family: Arial, sans-serif;
-    margin: 2rem;
+    margin: 0;
+    padding: 2rem;
     background: #f7f7fc;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
 }
 
 #inventory {
@@ -35,8 +40,8 @@ body {
 }
 
 .placed {
-    background: #82c91e;
-    border: 2px solid #2b8a3e;
+    background: transparent;
+    border: 2px solid transparent;
 }
 
 .preview {
@@ -121,7 +126,7 @@ body {
     top: 0; left: 0;
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     pointer-events: none;
     z-index: 10;
     border-radius: 7px;


### PR DESCRIPTION
## Summary
- allow selecting item color via new color input
- update CSS to center page contents and ensure item images fill cells
- store item color in inventory data and apply color to images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68648881ba6c8320870172b292edfefe