### PR TITLE
Add items.json source and fix layout overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@
             <input type="number" id="altura" placeholder="Altura" min="1" required>
             <label for="imagem">Imagem</label>
             <input type="file" id="imagem" accept="image/*">
+            <label for="cor">Cor do item</label>
+            <input type="color" id="cor" value="#2b8a3e">
             <button type="submit">Adicionar</button>
         </form>
     </div>

--- a/inventory.js
+++ b/inventory.js
@@ -7,11 +7,8 @@ export const itemList = document.getElementById('item-list');
 export const form = document.getElementById('item-form');
 export const itemsPanel = document.getElementById('items');
 
-let itemsData = [
-    { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null },
-    { id: generateId(), nome: 'Lança', width: 1, height: 3, img: null },
-    { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null },
-];
+// Será preenchido na inicialização a partir do arquivo JSON de itens
+let itemsData = [];
 let placedItems = [];
 
 export function getInventoryState() {
@@ -23,9 +20,9 @@ export function setInventoryState(data) {
     placedItems = data.placedItems;
 }
 
-export function initInventory() {
+export async function initInventory() {
     createGrid();
-    const loaded = loadInventory();
+    const loaded = await loadInventory();
     itemsData = loaded.itemsData;
     placedItems = loaded.placedItems;
     updateItemList();
@@ -53,6 +50,7 @@ export function updateItemList() {
         el.dataset.idx = idx;
         el.dataset.width = item.width;
         el.dataset.height = item.height;
+        el.style.borderColor = item.color;
         if (item.img) {
             const img = document.createElement('img');
             img.src = item.img;
@@ -73,8 +71,9 @@ export function getItemFormData() {
     const width = parseInt(document.getElementById('largura').value);
     const height = parseInt(document.getElementById('altura').value);
     const imgInput = document.getElementById('imagem');
+    const color = document.getElementById('cor').value || '#2b8a3e';
     if (!nome || width < 1 || height < 1 || width > COLS || height > ROWS) return null;
-    return { nome, width, height, imgInput };
+    return { nome, width, height, imgInput, color };
 }
 
 export function addNewItem(data) {
@@ -83,7 +82,8 @@ export function addNewItem(data) {
         nome: data.nome,
         width: data.width,
         height: data.height,
-        img: data.img
+        img: data.img,
+        color: data.color
     });
     updateItemList();
     saveInventory(itemsData, placedItems);
@@ -101,7 +101,8 @@ export function returnItemToPanel(item) {
         nome: item.nome,
         width: item.originalWidth ?? item.width,
         height: item.originalHeight ?? item.height,
-        img: item.img || null
+        img: item.img || null,
+        color: item.color
     });
     updateItemList();
     saveInventory(itemsData, placedItems);
@@ -185,7 +186,14 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             cell.classList.add('placed');
             cell.dataset.itemid = item.id;
             cell.title = item.nome || '';
-            if (dx === 0 && dy === 0) {
+            if (!item.img) {
+                cell.style.background = item.color;
+                cell.style.border = `2px solid ${item.color}`;
+                if (dx > 0) cell.style.borderLeft = '0';
+                if (dy > 0) cell.style.borderTop = '0';
+                if (dx < w - 1) cell.style.borderRight = '0';
+                if (dy < h - 1) cell.style.borderBottom = '0';
+            } else if (dx === 0 && dy === 0) {
                 removeGridImage(cell);
             }
         }
@@ -207,6 +215,7 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             height: h,
             rotacionado: item.rotacionado,
             img: item.img || null,
+            color: item.color,
             originalWidth: item.originalWidth ?? (item.rotacionado ? item.height : item.width),
             originalHeight: item.originalHeight ?? (item.rotacionado ? item.width : item.height)
         });
@@ -219,6 +228,7 @@ export function createItemImageElement(item, width, height, isGhost = false) {
     img.src = item.img;
     img.alt = item.nome;
     img.className = 'grid-item-img';
+    img.style.border = `2px solid ${item.color}`;
     if (!isGhost) {
         img.classList.add(`w${width}`, `h${height}`);
         if (item.rotacionado) {
@@ -240,6 +250,12 @@ export function resetCell(cell) {
     cell.classList.remove('placed', 'selected');
     delete cell.dataset.itemid;
     cell.title = '';
+    cell.style.border = '';
+    cell.style.borderLeft = '';
+    cell.style.borderTop = '';
+    cell.style.borderRight = '';
+    cell.style.borderBottom = '';
+    cell.style.background = '';
     removeGridImage(cell);
 }
 

--- a/items.json
+++ b/items.json
@@ -1,0 +1,5 @@
+[
+  {"nome": "Espada", "width": 2, "height": 1, "color": "#2b8a3e"},
+  {"nome": "Lança", "width": 1, "height": 3, "color": "#2b8a3e"},
+  {"nome": "Escudo", "width": 2, "height": 2, "color": "#2b8a3e"}
+]

--- a/main.js
+++ b/main.js
@@ -4,10 +4,10 @@ import { handleItemSubmit } from './inventory.js';
 import { initDragDrop, registerPanelDragHandlers } from './dragdrop.js';
 import { applyLayoutSettings } from './constants.js';
 
-window.addEventListener('DOMContentLoaded', () => {
+window.addEventListener('DOMContentLoaded', async () => {
     applyLayoutSettings();
     setupLogin();
-    initInventory();
+    await initInventory();
     registerPanelDragHandlers();
     initDragDrop();
     form.addEventListener('submit', async (e) => {

--- a/storage.js
+++ b/storage.js
@@ -5,16 +5,21 @@ function generateId() {
     return '_' + Math.random().toString(36).substr(2, 9);
 }
 
-function defaultItems() {
-    return [
-        { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null },
-        { id: generateId(), nome: 'Lan\u00e7a', width: 1, height: 3, img: null },
-        { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null }
-    ];
+async function fetchDefaultItems() {
+    const res = await fetch('items.json');
+    const data = await res.json();
+    return data.map(it => ({
+        id: generateId(),
+        nome: it.nome,
+        width: it.width,
+        height: it.height,
+        img: null,
+        color: typeof it.color === 'string' ? it.color : '#2b8a3e'
+    }));
 }
 
 function sanitizeItems(items) {
-    if (!Array.isArray(items)) return defaultItems();
+    if (!Array.isArray(items)) return [];
     const valid = [];
     for (const it of items) {
         const width = parseInt(it.width);
@@ -27,10 +32,11 @@ function sanitizeItems(items) {
             nome: it.nome,
             width,
             height,
-            img: it.img || null
+            img: it.img || null,
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e'
         });
     }
-    return valid.length ? valid : defaultItems();
+    return valid;
 }
 
 function sanitizePlaced(items) {
@@ -54,6 +60,7 @@ function sanitizePlaced(items) {
             height,
             rotacionado: !!it.rotacionado,
             img: it.img || null,
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e',
             originalWidth: it.originalWidth ?? width,
             originalHeight: it.originalHeight ?? height
         });
@@ -66,15 +73,17 @@ export function saveInventory(itemsData, placedItems) {
     localStorage.setItem('tetris-inventory', JSON.stringify(data));
 }
 
-export function loadInventory() {
+export async function loadInventory() {
     const raw = localStorage.getItem('tetris-inventory');
     if (!raw) {
-        return { itemsData: defaultItems(), placedItems: [] };
+        const itemsData = await fetchDefaultItems();
+        return { itemsData, placedItems: [] };
     }
     try {
         const obj = JSON.parse(raw);
         if (obj.version !== DATA_VERSION) throw new Error('version mismatch');
-        const itemsData = sanitizeItems(obj.itemsData);
+        let itemsData = sanitizeItems(obj.itemsData);
+        if (!itemsData.length) itemsData = await fetchDefaultItems();
         const placedItems = sanitizePlaced(obj.placedItems);
         return { itemsData, placedItems };
     } catch (e) {
@@ -83,6 +92,7 @@ export function loadInventory() {
         if (typeof alert === 'function') {
             alert('Dados do invent\u00e1rio estavam corrompidos e foram reiniciados.');
         }
-        return { itemsData: defaultItems(), placedItems: [] };
+        const itemsData = await fetchDefaultItems();
+        return { itemsData, placedItems: [] };
     }
 }

--- a/style.css
+++ b/style.css
@@ -8,8 +8,13 @@
 
 body {
     font-family: Arial, sans-serif;
-    margin: 2rem;
+    margin: 0;
+    padding: 2rem;
     background: #f7f7fc;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
 }
 
 #inventory {
@@ -35,8 +40,8 @@ body {
 }
 
 .placed {
-    background: #82c91e;
-    border: 2px solid #2b8a3e;
+    background: transparent;
+    border: 2px solid transparent;
 }
 
 .preview {
@@ -48,9 +53,17 @@ body {
     margin-top: 20px;
 }
 
+#item-list {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
 .item {
-    display: inline-block;
-    padding: 6px 18px;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
     margin: 0 10px 10px 0;
     background: #ffe066;
     border: 1px solid #fab005;
@@ -121,7 +134,7 @@ body {
     top: 0; left: 0;
     width: 100%;
     height: 100%;
-    object-fit: contain;
+    object-fit: cover;
     pointer-events: none;
     z-index: 10;
     border-radius: 7px;
@@ -186,6 +199,7 @@ body {
 
 #user-welcome {
     margin-bottom: 12px;
+    font-weight: bold;
 }
 
 #logout-btn {
@@ -218,6 +232,11 @@ body {
     padding: 5px;
     border-radius: 5px;
     border: 1px solid #bbb;
+}
+#login-screen label {
+    margin-top: 6px;
+    font-weight: bold;
+    align-self: flex-start;
 }
 #login-screen button {
     font-size: 1.1em;


### PR DESCRIPTION
## Summary
- load default items from a new `items.json` file asynchronously
- update inventory initialization to wait for the async load
- tweak item list and login screen styles to avoid overlapping text

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68648881ba6c8320870172b292edfefe