### PR TITLE
Adjust items panel position

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -33,14 +33,14 @@
 #items {
     position: fixed;
     top: 0;
-    right: 0;
+    left: 0;
     width: 260px;
     height: 100vh;
     padding: 20px;
     background: #fff;
-    box-shadow: -2px 0 8px rgba(0,0,0,0.2);
+    box-shadow: 2px 0 8px rgba(0,0,0,0.2);
     overflow-y: auto;
-    transform: translateX(100%);
+    transform: translateX(-100%);
     transition: transform 0.3s ease;
     z-index: 90;
 }


### PR DESCRIPTION
## Summary
- show item panel from the left side instead of right

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68654655f060832081cb5c4e75dde031