### PR TITLE
Move exit and reset buttons into sidebar

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -193,8 +193,13 @@
     font-weight: bold;
 }
 
+#side-actions {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 12px;
+}
+
 #logout-btn {
-    margin-left: 12px;
     background: #fa5252;
     color: white;
     border: none;
@@ -206,7 +211,6 @@
 }
 
 #reset-btn {
-    margin-left: 12px;
     background: #ffa94d;
     color: white;
     border: none;

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -8,8 +8,6 @@
 </head>
 <body>
     <div id="user-welcome"></div>
-    <button id="logout-btn">Sair</button>
-    <button id="reset-btn">Resetar Dados</button>
     <button id="menu-btn">&#9776;</button>
     
     <div id="drag-ghost"></div>
@@ -17,6 +15,10 @@
     <div id="inventory"></div>
 
     <div id="items">
+        <div id="side-actions">
+            <button id="logout-btn">Sair</button>
+            <button id="reset-btn">Resetar Dados</button>
+        </div>
         <h2>Itens</h2>
         <input id="item-search" type="text" placeholder="Buscar" maxlength="3">
         <div id="item-list"></div>


### PR DESCRIPTION
## Summary
- move Logout and Reset buttons into the sidebar section
- style sidebar actions so the buttons sit side by side

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865493a86348320862981fd2c7a7567