### PR TITLE
Fix drag handlers after grid removal

### DIFF
--- a/public/js/dragdrop.js
+++ b/public/js/dragdrop.js
@@ -12,6 +12,9 @@ let previousPlacement = null;
 let lastGhostPos = { x: null, y: null, valid: true };
 let selectedItemId = null;
 
+// Reaplica handlers sempre que a lista de itens é atualizada
+document.addEventListener('itemListUpdated', registerPanelDragHandlers);
+
 export function registerPanelDragHandlers() {
     const { itemsData } = getInventoryState();
     itemList.querySelectorAll('.item').forEach(el => {

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -77,6 +77,7 @@ export function updateItemList() {
             itemList.appendChild(el);
         });
     saveInventory(itemsData, placedItems);
+    document.dispatchEvent(new Event('itemListUpdated'));
 }
 
 export function getItemFormData() {


### PR DESCRIPTION
## Summary
- dispatch `itemListUpdated` event when the item list is rebuilt
- listen for this event in `dragdrop.js` to reapply panel drag handlers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(server starts)*

------
https://chatgpt.com/codex/tasks/task_b_6865cf3433d88320826d84e5d9a3d261