### PR TITLE
Improve item transparency and borders

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -22,6 +22,7 @@
 
 .placed {
     background: transparent;
+    background-color: transparent;
     border: 2px solid transparent;
 }
 
@@ -163,6 +164,8 @@
     object-position: center;
     pointer-events: none;
     z-index: 10;
+    border: 2px solid transparent;
+    background-color: transparent;
     border-radius: 7px;
     transition: transform 0.2s;
 }

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -207,8 +207,11 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
                 if (dy > 0) cell.style.borderTop = '0';
                 if (dx < w - 1) cell.style.borderRight = '0';
                 if (dy < h - 1) cell.style.borderBottom = '0';
-            } else if (dx === 0 && dy === 0) {
-                removeGridImage(cell);
+            } else {
+                cell.style.backgroundColor = 'transparent';
+                if (dx === 0 && dy === 0) {
+                    removeGridImage(cell);
+                }
             }
         }
     }
@@ -243,6 +246,7 @@ export function createItemImageElement(item, width, height, isGhost = false) {
     img.alt = item.nome;
     img.className = 'grid-item-img';
     img.style.border = `2px solid ${item.color}`;
+    img.style.backgroundColor = 'transparent';
     if (!isGhost) {
         img.classList.add(`w${width}`, `h${height}`);
         if (item.rotacionado) {


### PR DESCRIPTION
## Summary
- ensure placed cells and item images use a transparent background
- define default border and transparency on `.grid-item-img`
- keep cells transparent when adding items with images

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865dd1ee1bc8320ab7c462eafac1acc