### PR TITLE
Add right-click deletion for master

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -262,3 +262,18 @@
     border: 1px solid #ccc;
     border-radius: 4px;
 }
+
+.delete-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 20px;
+    height: 20px;
+    background-color: red;
+    color: white;
+    font-weight: bold;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    z-index: 10;
+}


### PR DESCRIPTION
## Summary
- master users can right-click placed items to show an on-screen delete button
- clicking the delete button prompts for confirmation and removes the item
- hide delete option when clicking elsewhere
- style delete button in inventory CSS

## Testing
- `npm test` *(fails: no test specified)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_b_6865df57088083209be9d2f2e61ac82d