### PR TITLE
Enable deletion of side panel items

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -64,6 +64,7 @@
     align-items: center;
     cursor: grab;
     user-select: none;
+    position: relative;
 }
 
 .item-preview {
@@ -264,6 +265,21 @@
 }
 
 .delete-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 20px;
+    height: 20px;
+    background-color: red;
+    color: white;
+    font-weight: bold;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    z-index: 10;
+}
+
+.delete-item-btn {
     position: absolute;
     top: 2px;
     right: 2px;


### PR DESCRIPTION
## Summary
- allow master users to delete catalog items via right-click
- style delete button for panel items

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865e4b089008320b39e2ef328fa8373