### PR TITLE
Add Darcula-inspired dark mode

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -26,3 +26,41 @@ body {
         --cell-size: 1.875rem;
     }
 }
+
+/* Dark mode styles */
+body.dark-mode {
+    background-color: #2B2B2B;
+    color: #A9B7C6;
+}
+
+body.dark-mode h1,
+body.dark-mode h2,
+body.dark-mode h3 {
+    color: #FFC66D;
+}
+
+body.dark-mode input,
+body.dark-mode button {
+    background-color: #3C3F41;
+    color: #A9B7C6;
+    border: 1px solid #555;
+}
+
+#toggle-theme {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    background: #ffe066;
+    border: 1px solid #fab005;
+    border-radius: 6px;
+    padding: 6px 10px;
+    cursor: pointer;
+    font-size: 1.2rem;
+    z-index: 100;
+}
+
+body.dark-mode #toggle-theme {
+    background: #4E94CE;
+    border-color: #6897BB;
+    color: #fff;
+}

--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -294,3 +294,37 @@
     cursor: pointer;
     z-index: 10;
 }
+
+/* Dark mode styles */
+body.dark-mode #inventory {
+    background: #444;
+}
+
+body.dark-mode .cell {
+    background: #3C3F41;
+    border-color: #555;
+}
+
+body.dark-mode #items {
+    background: #3C3F41;
+    border-color: #555;
+    box-shadow: 2px 0 8px rgba(0,0,0,0.6);
+}
+
+body.dark-mode .item-preview {
+    background: #3C3F41;
+    border-color: #555;
+}
+
+body.dark-mode #menu-btn {
+    background: #4E94CE;
+    border-color: #6897BB;
+    color: #fff;
+}
+
+body.dark-mode #item-form button,
+body.dark-mode #logout-btn,
+body.dark-mode #reset-btn {
+    background: #4E94CE;
+    color: #fff;
+}

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -64,3 +64,30 @@
     text-decoration: underline;
     cursor: pointer;
 }
+
+/* Dark mode styles */
+body.dark-mode #login-screen {
+    background: #2B2B2B;
+}
+
+body.dark-mode #login-box {
+    background: #3C3F41;
+    box-shadow: 0 2px 10px rgba(0,0,0,0.6);
+}
+
+body.dark-mode #login-screen label,
+body.dark-mode #login-screen a {
+    color: #A9B7C6;
+}
+
+body.dark-mode #login-screen input,
+body.dark-mode #login-screen button {
+    background-color: #3C3F41;
+    color: #A9B7C6;
+    border: 1px solid #555;
+}
+
+body.dark-mode #login-screen button {
+    background: #4E94CE;
+    color: #fff;
+}

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -9,6 +9,7 @@
 <body>
     <div id="user-welcome"></div>
     <button id="menu-btn">&#9776;</button>
+    <button id="toggle-theme">🌙</button>
     
     <div id="drag-ghost"></div>
     <h1>Inventário Tetris</h1>

--- a/public/js/inventory-page.js
+++ b/public/js/inventory-page.js
@@ -3,8 +3,10 @@ import { initInventory, form, searchInput, updateItemList } from './inventory.js
 import { handleItemSubmit } from './inventory.js';
 import { initDragDrop, registerPanelDragHandlers } from './dragdrop.js';
 import { applyLayoutSettings } from './constants.js';
+import { setupThemeToggle } from './theme.js';
 
 window.addEventListener('DOMContentLoaded', async () => {
+    setupThemeToggle();
     const userWelcome = document.getElementById('user-welcome');
     const logoutBtn = document.getElementById('logout-btn');
     const resetBtn = document.getElementById('reset-btn');

--- a/public/js/login-page.js
+++ b/public/js/login-page.js
@@ -1,10 +1,12 @@
 import { session, registerUser, validateLogin, setPerguntaSecreta, validarPerguntaSecreta, redefinirSenha } from './login.js';
+import { setupThemeToggle } from './theme.js';
 
 function getUsers() {
     return JSON.parse(localStorage.getItem('tetris-users') || '{}');
 }
 
 window.addEventListener('DOMContentLoaded', () => {
+    setupThemeToggle();
     const loginForm = document.getElementById('login-form');
     const loginUser = document.getElementById('login-user');
     const loginPass = document.getElementById('login-pass');

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,0 +1,16 @@
+export function setupThemeToggle() {
+    const toggleBtn = document.getElementById('toggle-theme');
+    if (!toggleBtn) return;
+    const current = localStorage.getItem('theme');
+    if (current === 'dark') {
+        document.body.classList.add('dark-mode');
+        toggleBtn.textContent = '☀️';
+    } else {
+        toggleBtn.textContent = '🌙';
+    }
+    toggleBtn.addEventListener('click', () => {
+        const isDark = document.body.classList.toggle('dark-mode');
+        toggleBtn.textContent = isDark ? '☀️' : '🌙';
+        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+    });
+}

--- a/public/login.html
+++ b/public/login.html
@@ -7,6 +7,7 @@
     <link rel="stylesheet" href="css/login.css">
 </head>
 <body>
+    <button id="toggle-theme">🌙</button>
     <div id="login-screen">
         <div id="login-box">
             <form id="login-form">


### PR DESCRIPTION
## Summary
- add dark mode CSS rules
- create theme toggle button on login and inventory pages
- implement theme toggle script with localStorage persistence

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865ef712e288320a8383864d7a8e2e9