### PR TITLE
Add theme toggle support

### DIFF
--- a/public/css/common.css
+++ b/public/css/common.css
@@ -33,6 +33,11 @@ body.dark-mode {
     color: #A9B7C6;
 }
 
+body.light-mode {
+    background-color: #f7f7fc;
+    color: #222;
+}
+
 body.dark-mode h1,
 body.dark-mode h2,
 body.dark-mode h3 {
@@ -44,6 +49,13 @@ body.dark-mode button {
     background-color: #3C3F41;
     color: #A9B7C6;
     border: 1px solid #555;
+}
+
+body.light-mode input,
+body.light-mode button {
+    background-color: #fff;
+    color: #000;
+    border: 1px solid #ccc;
 }
 
 #toggle-theme {

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,16 +1,29 @@
+function applyTheme(theme) {
+    const body = document.body;
+    const toggleBtn = document.getElementById('toggle-theme');
+    if (!toggleBtn) return;
+    if (theme === 'dark') {
+        body.classList.add('dark-mode');
+        body.classList.remove('light-mode');
+        toggleBtn.textContent = '☀️';
+    } else {
+        body.classList.remove('dark-mode');
+        body.classList.add('light-mode');
+        toggleBtn.textContent = '🌙';
+    }
+    localStorage.setItem('theme', theme);
+}
+
 export function setupThemeToggle() {
     const toggleBtn = document.getElementById('toggle-theme');
     if (!toggleBtn) return;
-    const current = localStorage.getItem('theme');
-    if (current === 'dark') {
-        document.body.classList.add('dark-mode');
-        toggleBtn.textContent = '☀️';
-    } else {
-        toggleBtn.textContent = '🌙';
-    }
+    const savedTheme = localStorage.getItem('theme') || 'light';
+    applyTheme(savedTheme);
     toggleBtn.addEventListener('click', () => {
-        const isDark = document.body.classList.toggle('dark-mode');
-        toggleBtn.textContent = isDark ? '☀️' : '🌙';
-        localStorage.setItem('theme', isDark ? 'dark' : 'light');
+        const current = document.body.classList.contains('dark-mode') ? 'dark' : 'light';
+        const next = current === 'dark' ? 'light' : 'dark';
+        applyTheme(next);
     });
 }
+
+export { applyTheme };


### PR DESCRIPTION
## Summary
- add light-mode CSS rules
- implement theme toggle with persistent mode using `applyTheme`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6865f134890c8320ae95753bc51f5bce