### PR TITLE
Add frontend registration and connect auth to server

### DIFF
--- a/public/css/login.css
+++ b/public/css/login.css
@@ -22,7 +22,21 @@
     text-align: center;
 }
 
-#login-box {
+#register-form {
+    display: grid;
+    gap: 10px;
+    width: 250px;
+    text-align: center;
+}
+
+#register-err {
+    color: red;
+    margin-top: 10px;
+}
+
+#login-box,
+#register-box,
+#initial-screen {
     background: #fff;
     padding: 20px;
     border-radius: 12px;
@@ -70,7 +84,9 @@ body.dark-mode #login-screen {
     background: #2B2B2B;
 }
 
-body.dark-mode #login-box {
+body.dark-mode #login-box,
+body.dark-mode #register-box,
+body.dark-mode #initial-screen {
     background: #3C3F41;
     box-shadow: 0 2px 10px rgba(0,0,0,0.6);
 }

--- a/public/login.html
+++ b/public/login.html
@@ -9,15 +9,35 @@
 <body>
     <button id="toggle-theme">🌙</button>
     <div id="login-screen">
-        <div id="login-box">
+        <div id="initial-screen">
+            <button id="btn-show-login">Entrar</button>
+            <button id="btn-show-register">Cadastrar</button>
+        </div>
+        <div id="login-box" style="display:none;">
             <form id="login-form">
-                <label for="login-user">Nome</label>
+                <label for="login-user">Nome de usuário</label>
                 <input id="login-user" type="text" placeholder="Nome">
                 <label for="login-pass">Senha</label>
                 <input id="login-pass" type="password" placeholder="Senha">
                 <button id="login-btn" type="submit">Entrar</button>
                 <a href="#" id="forgot-pass">Esqueci minha senha</a>
+                <a href="#" id="goto-register">Cadastrar</a>
                 <div id="login-err"></div>
+            </form>
+        </div>
+        <div id="register-box" style="display:none;">
+            <form id="register-form">
+                <label for="register-user">Nome de usuário</label>
+                <input id="register-user" type="text" placeholder="Nome">
+                <label for="register-pass">Senha</label>
+                <input id="register-pass" type="password" placeholder="Senha">
+                <label for="register-question">Pergunta secreta (opcional)</label>
+                <input id="register-question" type="text" placeholder="Pergunta secreta">
+                <label for="register-answer">Resposta secreta (opcional)</label>
+                <input id="register-answer" type="text" placeholder="Resposta secreta">
+                <button id="register-btn" type="submit">Cadastrar</button>
+                <a href="#" id="goto-login">Já tenho conta</a>
+                <div id="register-err"></div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- update login page to include registration form and initial screen
- style new login/register elements and dark mode adjustments
- implement client-side logic to fetch login, register and password reset endpoints

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6866abc2ad488320ba72fa2cbca11dd4