### PR TITLE
Implement item stress tracking

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -80,6 +80,27 @@
     overflow: hidden;
 }
 
+.item-preview.broken {
+    border-color: #ccc;
+    background: transparent;
+}
+
+.item-stress {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: rgba(0,0,0,0.5);
+    color: white;
+    font-size: 0.55rem;
+    text-align: center;
+    pointer-events: none;
+}
+
+.broken img {
+    opacity: 0.3;
+}
+
 .item-preview img {
     width: 100%;
     height: 100%;
@@ -168,6 +189,18 @@
     background-color: transparent;
     border-radius: 7px;
     transition: transform 0.2s;
+}
+.stress-display {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    background: rgba(0,0,0,0.5);
+    color: white;
+    font-size: 0.55rem;
+    text-align: center;
+    pointer-events: none;
+    z-index: 15;
 }
 .rotacionado {
     transform: rotate(90deg);

--- a/public/js/dragdrop.js
+++ b/public/js/dragdrop.js
@@ -1,4 +1,4 @@
-import { inventory, itemList, clearGridSelection, removeItemFromGrid, clearCells, canPlace, placeItem, createItemImageElement, returnItemToPanel, removeItemFromPanel, getInventoryState, setInventoryState, updateItemList } from './inventory.js';
+import { inventory, itemList, clearGridSelection, removeItemFromGrid, clearCells, canPlace, placeItem, createItemImageElement, returnItemToPanel, removeItemFromPanel, getInventoryState, setInventoryState, updateItemList, adjustItemStress } from './inventory.js';
 import { saveInventory } from './storage.js';
 import { ROWS, COLS, CELL_GAP, getCellSize } from './constants.js';
 import { session } from './login.js';
@@ -77,7 +77,21 @@ function onKeyDown(e) {
         selectedItemId = null;
         return;
     }
-    if (!draggedItem) return;
+    if (!draggedItem) {
+        if (session.isMaster && selectedItemId) {
+            if (e.key === '+' || e.key === '=' || e.key === 'Add' || e.key === 'NumpadAdd') {
+                e.preventDefault();
+                adjustItemStress(selectedItemId, 1);
+                return;
+            }
+            if (e.key === '-' || e.key === '_' || e.key === 'Subtract' || e.key === 'NumpadSubtract') {
+                e.preventDefault();
+                adjustItemStress(selectedItemId, -1);
+                return;
+            }
+        }
+        return;
+    }
     if (e.key.toLowerCase() === 'r') {
         previewRotation = !previewRotation;
         currentPreviewSize = {

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -1,5 +1,5 @@
 import { ROWS, COLS } from './constants.js';
-const DATA_VERSION = 1;
+const DATA_VERSION = 2;
 
 function generateId() {
     return '_' + Math.random().toString(36).substr(2, 9);
@@ -14,15 +14,17 @@ async function fetchDefaultItems() {
         width: it.width,
         height: it.height,
         img: typeof it.img === 'string' && it.img.length ? it.img : null,
-        color: typeof it.color === 'string' ? it.color : '#2b8a3e'
+        color: typeof it.color === 'string' ? it.color : '#2b8a3e',
+        maxEstresse: Number.isFinite(it.maxEstresse) ? it.maxEstresse : 3,
+        estresseAtual: Number.isFinite(it.estresseAtual) ? it.estresseAtual : 0
     }));
 }
 
 function defaultItems() {
     return [
-        { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null, color: '#2b8a3e' },
-        { id: generateId(), nome: 'Lan\u00e7a', width: 1, height: 3, img: null, color: '#2b8a3e' },
-        { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null, color: '#2b8a3e' }
+        { id: generateId(), nome: 'Espada', width: 2, height: 1, img: null, color: '#2b8a3e', maxEstresse: 3, estresseAtual: 0 },
+        { id: generateId(), nome: 'Lan\u00e7a', width: 1, height: 3, img: null, color: '#2b8a3e', maxEstresse: 3, estresseAtual: 0 },
+        { id: generateId(), nome: 'Escudo', width: 2, height: 2, img: null, color: '#2b8a3e', maxEstresse: 3, estresseAtual: 0 }
     ];
 }
 
@@ -41,7 +43,9 @@ function sanitizeItems(items) {
             width,
             height,
             img: it.img || null,
-            color: typeof it.color === 'string' ? it.color : '#2b8a3e'
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e',
+            maxEstresse: Number.isFinite(parseInt(it.maxEstresse)) ? parseInt(it.maxEstresse) : 3,
+            estresseAtual: Number.isFinite(parseInt(it.estresseAtual)) ? parseInt(it.estresseAtual) : 0
         });
     }
     return valid;
@@ -70,7 +74,9 @@ function sanitizePlaced(items) {
             img: it.img || null,
             color: typeof it.color === 'string' ? it.color : '#2b8a3e',
             originalWidth: it.originalWidth ?? width,
-            originalHeight: it.originalHeight ?? height
+            originalHeight: it.originalHeight ?? height,
+            maxEstresse: Number.isFinite(parseInt(it.maxEstresse)) ? parseInt(it.maxEstresse) : 3,
+            estresseAtual: Number.isFinite(parseInt(it.estresseAtual)) ? parseInt(it.estresseAtual) : 0
         });
     }
     return valid;


### PR DESCRIPTION
## Summary
- add maxEstresse/estresseAtual to item data
- display stress on item previews and placed items
- mark items broken when stress reaches maximum
- allow masters to adjust stress with + and - keys
- update default data and storage schema

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(runs server)*

------
https://chatgpt.com/codex/tasks/task_b_6867fa8b0f4083208f08f7274dbdbcbb