### PR TITLE
Add Oblivio sheet with attributes and skills

### DIFF
--- a/public/css/oblivio.css
+++ b/public/css/oblivio.css
@@ -1,0 +1,47 @@
+.attr-list, #skill-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 10px;
+}
+
+.attr {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.attr-name {
+    flex: 1;
+    text-align: left;
+}
+
+.attr .controls {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.attr .value {
+    min-width: 2em;
+    text-align: center;
+    display: inline-block;
+}
+
+.skill {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.skill input {
+    flex: 1;
+}
+
+.skill button.remove {
+    padding: 4px 8px;
+}
+
+#add-skill {
+    margin-top: 10px;
+}

--- a/public/js/oblivio-page.js
+++ b/public/js/oblivio-page.js
@@ -1,0 +1,89 @@
+import { setupThemeToggle } from './theme.js';
+
+const ATTRS = [
+    'Carne', 'Fôlego', 'Dano', 'Força', 'Fuga',
+    'Determinação', 'Mente', 'Coragem', 'Proteção', 'Velocidade'
+];
+
+function createAttrRow(name) {
+    const row = document.createElement('div');
+    row.className = 'attr';
+
+    const label = document.createElement('span');
+    label.className = 'attr-name';
+    label.textContent = name;
+
+    const controls = document.createElement('div');
+    controls.className = 'controls';
+
+    const dec = document.createElement('button');
+    dec.className = 'btn dec';
+    dec.textContent = '-';
+
+    const val = document.createElement('span');
+    val.className = 'value';
+    val.textContent = '0';
+    let value = 0;
+
+    const inc = document.createElement('button');
+    inc.className = 'btn inc';
+    inc.textContent = '+';
+
+    inc.addEventListener('click', () => {
+        value++;
+        val.textContent = String(value);
+    });
+
+    dec.addEventListener('click', () => {
+        if (value > 0) {
+            value--;
+            val.textContent = String(value);
+        }
+    });
+
+    controls.append(dec, val, inc);
+    row.append(label, controls);
+    return row;
+}
+
+function addSkill(name = '', type = 'ativa') {
+    const list = document.getElementById('skill-list');
+    const div = document.createElement('div');
+    div.className = 'skill';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Nome';
+    input.value = name;
+
+    const select = document.createElement('select');
+    const optA = document.createElement('option');
+    optA.value = 'ativa';
+    optA.textContent = 'Ativa';
+    const optP = document.createElement('option');
+    optP.value = 'passiva';
+    optP.textContent = 'Passiva';
+    select.append(optA, optP);
+    select.value = type;
+
+    const remove = document.createElement('button');
+    remove.className = 'btn remove';
+    remove.textContent = '✕';
+    remove.addEventListener('click', () => {
+        list.removeChild(div);
+    });
+
+    div.append(input, select, remove);
+    list.appendChild(div);
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+    setupThemeToggle();
+
+    const attrList = document.getElementById('attr-list');
+    ATTRS.forEach(a => {
+        attrList.appendChild(createAttrRow(a));
+    });
+
+    document.getElementById('add-skill').addEventListener('click', () => addSkill());
+});

--- a/public/oblivio.html
+++ b/public/oblivio.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Ficha Oblívio</title>
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="css/common.css">
+    <link rel="stylesheet" href="css/oblivio.css">
+</head>
+<body>
+    <button id="toggle-theme" class="btn">🌙</button>
+    <h1>Ficha Oblívio</h1>
+    <div id="attributes" class="panel">
+        <h2>Atributos</h2>
+        <div id="attr-list" class="attr-list"></div>
+    </div>
+    <div id="skills" class="panel">
+        <h2>Habilidades</h2>
+        <div id="skill-list"></div>
+        <button id="add-skill" class="btn">Nova habilidade</button>
+    </div>
+    <script type="module" src="js/oblivio-page.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new Oblívio character sheet page with attribute controls and editable skills
- style the new sheet
- implement script to handle attributes and skills

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_686809ba4b508320a1bbaee861930c28