### PR TITLE
Fix drag ghost and item visuals

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -93,7 +93,9 @@
     background: rgba(0,0,0,0.5);
     color: white;
     font-size: 0.55rem;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     pointer-events: none;
 }
 
@@ -174,11 +176,18 @@
     box-shadow: 0 1px 3px #0002;
 }
 
-.grid-item-img {
+.grid-item-wrapper {
     position: absolute;
-    top: 0; left: 0;
+    top: 0;
+    left: 0;
+    pointer-events: none;
+}
+
+.grid-item-img {
     width: 100%;
     height: 100%;
+    max-width: 100%;
+    max-height: 100%;
     box-sizing: border-box;
     display: block;
     object-fit: contain;
@@ -198,7 +207,9 @@
     background: rgba(0,0,0,0.5);
     color: white;
     font-size: 0.55rem;
-    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     pointer-events: none;
     z-index: 15;
 }

--- a/public/js/dragdrop.js
+++ b/public/js/dragdrop.js
@@ -320,6 +320,7 @@ function removePreview() {
 function hideGhost() {
     dragGhost.style.display = 'none';
     dragGhost.innerHTML = '';
+    dragGhost.className = '';
     lastGhostPos = { x: null, y: null, valid: true };
 }
 

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -237,20 +237,21 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
     if (item.img) {
         const cell0 = inventory.children[y * COLS + x];
         cell0.classList.add('has-img');
-        const img = createItemImageElement({ ...item, rotacionado: fromRedraw ? item.rotacionado : item.rotacionado }, w, h);
+        const wrapper = createItemImageElement({ ...item, rotacionado: fromRedraw ? item.rotacionado : item.rotacionado }, w, h);
         removeGridImage(cell0);
-        cell0.appendChild(img);
-        const stressEl = createStressElement(item, w, h);
-        removeStressDisplay(cell0);
-        cell0.appendChild(stressEl);
+        cell0.appendChild(wrapper);
         const broken = (item.estresseAtual ?? 0) >= (item.maxEstresse ?? 3);
         if (broken) {
-            img.style.opacity = '0.3';
-            img.style.border = '2px solid #ccc';
+            const imgEl = wrapper.querySelector('.grid-item-img');
+            if (imgEl) {
+                imgEl.style.opacity = '0.3';
+                imgEl.style.border = '2px solid #ccc';
+            }
         }
     } else {
         const cell0 = inventory.children[y * COLS + x];
-        const stressEl = createStressElement(item, w, h);
+        removeGridImage(cell0);
+        const stressEl = createStressElement(item, w);
         removeStressDisplay(cell0);
         cell0.appendChild(stressEl);
     }
@@ -275,24 +276,29 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
 }
 
 export function createItemImageElement(item, width, height, isGhost = false) {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'grid-item-wrapper';
+    wrapper.classList.add(`w${width}`, `h${height}`);
+    if (item.rotacionado) {
+        wrapper.classList.add('rotacionado');
+    }
+
     const img = document.createElement('img');
     img.src = item.img;
     img.alt = item.nome;
     img.className = 'grid-item-img';
     img.style.border = `2px solid ${item.color}`;
     img.style.backgroundColor = 'transparent';
+    wrapper.appendChild(img);
+
     if (!isGhost) {
-        img.classList.add(`w${width}`, `h${height}`);
-        if (item.rotacionado) {
-            img.classList.add('rotacionado');
-        }
-    } else if (item.rotacionado) {
-        img.classList.add('rotacionado');
+        const stress = createStressElement(item, width);
+        wrapper.appendChild(stress);
     }
-    return img;
+    return wrapper;
 }
 
-export function createStressElement(item, width, height) {
+export function createStressElement(item, width) {
     const div = document.createElement('div');
     div.className = 'stress-display';
     div.textContent = `${item.estresseAtual ?? 0} / ${item.maxEstresse ?? 3}`;
@@ -304,12 +310,12 @@ export function createStressElement(item, width, height) {
 
 export function removeStressDisplay(cell) {
     const el = cell.querySelector('.stress-display');
-    if (el) cell.removeChild(el);
+    if (el) el.remove();
 }
 
 export function removeGridImage(cell) {
-    const img = cell.querySelector('.grid-item-img');
-    if (img) cell.removeChild(img);
+    const wrapper = cell.querySelector('.grid-item-wrapper');
+    if (wrapper) wrapper.remove();
     cell.classList.remove('has-img');
 }
 


### PR DESCRIPTION
## Summary
- hide ghost classes properly after drop
- wrap grid items so stress bar rotates with image
- center stress text and unify styles

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68682571c70c832096c4b55467eb41c2