### PR TITLE
Fix DOM element initialization timing

### DIFF
--- a/public/js/inventory-page.js
+++ b/public/js/inventory-page.js
@@ -1,5 +1,5 @@
 import { session } from './login.js';
-import { initInventory, form, searchInput, updateItemList } from './inventory.js';
+import { cacheDomElements, initInventory, form, searchInput, updateItemList } from './inventory.js';
 import { handleItemSubmit } from './inventory.js';
 import { initDragDrop, registerPanelDragHandlers } from './dragdrop.js';
 import { applyLayoutSettings } from './constants.js';
@@ -7,6 +7,7 @@ import { setupThemeToggle } from './theme.js';
 
 window.addEventListener('DOMContentLoaded', async () => {
     setupThemeToggle();
+    cacheDomElements();
     const userWelcome = document.getElementById('user-welcome');
     const logoutBtn = document.getElementById('logout-btn');
     const resetBtn = document.getElementById('reset-btn');

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -2,11 +2,21 @@ import { saveInventory, loadInventory } from './storage.js';
 import { session } from './login.js';
 import { ROWS, COLS } from './constants.js';
 
-export const inventory = document.getElementById('inventory');
-export const itemList = document.getElementById('item-list');
-export const form = document.getElementById('item-form');
-export const itemsPanel = document.getElementById('items');
-export const searchInput = document.getElementById('item-search');
+// DOM elements are resolved after the document is ready. They are declared
+// using `let` so they can be assigned during initialization.
+export let inventory;
+export let itemList;
+export let form;
+export let itemsPanel;
+export let searchInput;
+
+export function cacheDomElements() {
+    inventory = document.getElementById('inventory');
+    itemList = document.getElementById('item-list');
+    form = document.getElementById('item-form');
+    itemsPanel = document.getElementById('items');
+    searchInput = document.getElementById('item-search');
+}
 
 let itemsData = [];
 


### PR DESCRIPTION
## Summary
- initialize DOM references after the document is parsed
- wire `inventory-page.js` to call the new initializer before accessing elements

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68689f204c508320a96ddcddf7a65705