### PR TITLE
Add question endpoint and update login page

### DIFF
--- a/public/js/login-page.js
+++ b/public/js/login-page.js
@@ -118,13 +118,13 @@ window.addEventListener('DOMContentLoaded', () => {
     const username = prompt('Nome de usuário:');
     if (!username) return;
     try {
-      const res = await fetch('/users');
-      const users = await res.json();
-      if (!users[username] || !users[username].pergunta) {
-        alert('Usuário não encontrado ou sem pergunta secreta cadastrada.');
+      const res = await fetch(`/question/${encodeURIComponent(username)}`);
+      const data = await res.json();
+      if (!res.ok) {
+        alert(data.error || 'Usuário não encontrado ou sem pergunta secreta cadastrada.');
         return;
       }
-      const question = users[username].pergunta;
+      const question = data.pergunta;
       const answer = prompt(question);
       if (!answer) return;
       const newPass = prompt('Digite a nova senha:');

--- a/server.js
+++ b/server.js
@@ -62,6 +62,17 @@ app.post('/reset-password', (req, res) => {
   res.json({ message: 'Senha redefinida com sucesso!' });
 });
 
+// Return only the secret question for a specific user
+app.get('/question/:username', (req, res) => {
+  const { username } = req.params;
+  const users = loadUsers();
+  const user = users[username];
+  if (!user || !user.pergunta) {
+    return res.status(404).json({ error: 'Usuário não encontrado ou sem pergunta secreta.' });
+  }
+  res.json({ pergunta: user.pergunta });
+});
+
 // List all users (only for development/testing)
 app.get('/users', (req, res) => {
   const users = loadUsers();


### PR DESCRIPTION
## Summary
- implement `GET /question/:username` endpoint to fetch just the secret question
- update password recovery flow in `login-page.js` to use the new route

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6869207c296c8320b116f8aa3cdf9fd6