### PR TITLE
Add env var for users.json path

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ Pré-requisitos: **Node.js 18+** e **Python 3** caso queira utilizar o script de
 
    A rota `/master-hash` permite consultar o valor da variável de ambiente `MASTER_PASSWORD_HASH`, caso ela esteja definida. Defina essa variável antes de iniciar o servidor se precisar fornecer o hash de uma senha mestre externa.
 
+   Você também pode definir `USERS_FILE_PATH` para alterar o local do arquivo `users.json`. O diretório será criado automaticamente caso não exista.
+
 
 ## 📑 users.json
 O arquivo `server/users.json` é gerado automaticamente na primeira execução do servidor e armazena os usuários cadastrados. Se quiser reiniciar os cadastros, exclua esse arquivo antes de iniciar o servidor.
@@ -214,6 +216,8 @@ fetch('http://localhost:3000/login')
 ```
 
 The `/master-hash` endpoint returns the value of the `MASTER_PASSWORD_HASH` environment variable when it is defined. Set this variable before starting the server if you need to provide your own master password hash.
+
+You can also set `USERS_FILE_PATH` to change where the `users.json` file is stored. The folder will be created automatically if it does not exist.
 
 ### `users.json`
 The file `server/users.json` is created automatically when the server first starts and stores all registered users. Delete this file before launching the server if you wish to reset the credentials.

--- a/server/storage.js
+++ b/server/storage.js
@@ -1,10 +1,17 @@
 const fs = require('fs');
 const path = require('path');
 
-const USERS_FILE = path.join(__dirname, 'users.json');
+// Allow overriding the users file location with the USERS_FILE_PATH environment
+// variable, falling back to the default path within the server directory.
+const DEFAULT_USERS_FILE = path.join(__dirname, 'users.json');
+const USERS_FILE = process.env.USERS_FILE_PATH
+  ? path.resolve(process.env.USERS_FILE_PATH)
+  : DEFAULT_USERS_FILE;
 
 function ensureUsersFile() {
   if (!fs.existsSync(USERS_FILE)) {
+    // Create the directory tree if a custom path is provided
+    fs.mkdirSync(path.dirname(USERS_FILE), { recursive: true });
     fs.writeFileSync(USERS_FILE, JSON.stringify({}), 'utf-8');
   }
 }


### PR DESCRIPTION
## Summary
- allow overriding `users.json` path via `USERS_FILE_PATH`
- document new variable in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6869207dae04832081bdbe0c3d2d2694