### PR TITLE
Improve user data storage

### DIFF
--- a/server/storage.js
+++ b/server/storage.js
@@ -5,18 +5,40 @@ const USERS_FILE = path.join(__dirname, 'users.json');
 
 function ensureUsersFile() {
   if (!fs.existsSync(USERS_FILE)) {
-    fs.writeFileSync(USERS_FILE, JSON.stringify({}), 'utf-8');
+    try {
+      fs.writeFileSync(USERS_FILE, JSON.stringify({}), 'utf-8');
+    } catch (err) {
+      throw err;
+    }
   }
 }
 
 function loadUsers() {
   ensureUsersFile();
-  const data = fs.readFileSync(USERS_FILE, 'utf-8');
-  return JSON.parse(data || '{}');
+  try {
+    const data = fs.readFileSync(USERS_FILE, 'utf-8');
+    return JSON.parse(data || '{}');
+  } catch (err) {
+    throw err;
+  }
 }
 
 function saveUsers(usersObj) {
-  fs.writeFileSync(USERS_FILE, JSON.stringify(usersObj, null, 2), 'utf-8');
+  const tempFile = `${USERS_FILE}.tmp`;
+  const data = JSON.stringify(usersObj, null, 2);
+  try {
+    fs.writeFileSync(tempFile, data, 'utf-8');
+    fs.renameSync(tempFile, USERS_FILE);
+  } catch (err) {
+    try {
+      if (fs.existsSync(tempFile)) {
+        fs.unlinkSync(tempFile);
+      }
+    } catch (_) {
+      // ignore cleanup errors
+    }
+    throw err;
+  }
 }
 
 module.exports = { USERS_FILE, ensureUsersFile, loadUsers, saveUsers };


### PR DESCRIPTION
## Summary
- make user writes atomic via temp file
- handle file errors with try/catch and propagate them to caller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_6869207f4d108320973fc48302f9ce90