### PR TITLE
Add helmet middleware and validate inputs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "express-validator": "^7.2.1",
+        "helmet": "^8.1.0"
       }
     },
     "node_modules/accepts": {
@@ -264,6 +266,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-validator": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-7.2.1.tgz",
+      "integrity": "sha512-CjNE6aakfpuwGaHQZ3m8ltCG2Qvivd7RHtVMS/6nVxOM7xVGqr4bhflsm4+N5FP5zI7Zxp+Hae+9RE+o8e3ZOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "validator": "~13.12.0"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -381,6 +396,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/helmet": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+      "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -437,6 +461,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
       "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
     "node_modules/math-intrinsics": {
@@ -804,6 +834,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/validator": {
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.12.0.tgz",
+      "integrity": "sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "express-validator": "^7.2.1",
+    "helmet": "^8.1.0"
   }
 }

--- a/server.js
+++ b/server.js
@@ -1,21 +1,33 @@
 const express = require('express');
 const path = require('path');
+const helmet = require('helmet');
+const { body, validationResult } = require('express-validator');
 const { ensureUsersFile, loadUsers } = require('./server/storage');
 const { registerUser, authenticateUser, resetPassword } = require('./server/auth');
 
 const app = express();
 
 app.use(express.json());
+app.use(helmet());
 app.use(express.static(path.join(__dirname, 'public')));
 
 ensureUsersFile();
 
-app.post('/register', (req, res) => {
-  const { username, password, pergunta, resposta } = req.body;
-  if (!username || !password) {
-    return res.status(400).json({ error: 'Nome de usu\u00e1rio e senha s\u00e3o obrigat\u00f3rios.' });
-  }
-  const result = registerUser(username, password, pergunta, resposta);
+app.post(
+  '/register',
+  [
+    body('username').trim().notEmpty().withMessage('Nome de usu\u00e1rio \u00e9 obrigat\u00f3rio.'),
+    body('password').notEmpty().withMessage('Senha \u00e9 obrigat\u00f3ria.'),
+    body('pergunta').optional().isString(),
+    body('resposta').optional().isString()
+  ],
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, password, pergunta, resposta } = req.body;
+    const result = registerUser(username, password, pergunta, resposta);
   if (!result.created) {
     if (result.code === 'exists') {
       return res.status(409).json({ error: 'Nome de usu\u00e1rio j\u00e1 est\u00e1 em uso.' });
@@ -25,12 +37,19 @@ app.post('/register', (req, res) => {
   res.status(201).json({ message: 'Usu\u00e1rio registrado com sucesso!' });
 });
 
-app.post('/login', (req, res) => {
-  const { username, password } = req.body;
-  if (!username || !password) {
-    return res.status(400).json({ error: 'Nome de usu\u00e1rio e senha s\u00e3o obrigat\u00f3rios.' });
-  }
-  const result = authenticateUser(username, password);
+app.post(
+  '/login',
+  [
+    body('username').trim().notEmpty().withMessage('Nome de usu\u00e1rio \u00e9 obrigat\u00f3rio.'),
+    body('password').notEmpty().withMessage('Senha \u00e9 obrigat\u00f3ria.')
+  ],
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, password } = req.body;
+    const result = authenticateUser(username, password);
   if (!result.ok) {
     if (result.code === 'notfound') {
       return res.status(401).json({ error: 'Usu\u00e1rio n\u00e3o encontrado.' });
@@ -44,12 +63,20 @@ app.post('/login', (req, res) => {
   });
 });
 
-app.post('/reset-password', (req, res) => {
-  const { username, resposta, novaSenha } = req.body;
-  if (!username || !resposta || !novaSenha) {
-    return res.status(400).json({ error: 'Nome de usu\u00e1rio, resposta e nova senha s\u00e3o obrigat\u00f3rios.' });
-  }
-  const result = resetPassword(username, resposta, novaSenha);
+app.post(
+  '/reset-password',
+  [
+    body('username').trim().notEmpty().withMessage('Nome de usu\u00e1rio \u00e9 obrigat\u00f3rio.'),
+    body('resposta').notEmpty().withMessage('Resposta \u00e9 obrigat\u00f3ria.'),
+    body('novaSenha').notEmpty().withMessage('Nova senha \u00e9 obrigat\u00f3ria.')
+  ],
+  (req, res) => {
+    const errors = validationResult(req);
+    if (!errors.isEmpty()) {
+      return res.status(400).json({ errors: errors.array() });
+    }
+    const { username, resposta, novaSenha } = req.body;
+    const result = resetPassword(username, resposta, novaSenha);
   if (!result.ok) {
     if (result.code === 'notfound') {
       return res.status(404).json({ error: 'Usu\u00e1rio n\u00e3o encontrado ou sem pergunta secreta.' });


### PR DESCRIPTION
## Summary
- install helmet and express-validator
- secure Express app with helmet
- validate request bodies in `/register`, `/login`, and `/reset-password`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68692086e09883208080312b46620fc4