### PR TITLE
Refactor drag and drop into modules

### DIFF
--- a/public/js/context-handlers.js
+++ b/public/js/context-handlers.js
@@ -1,0 +1,109 @@
+import { session } from './login.js';
+import { removeItemFromPanel, updateItemList, readImageFile, getInventoryState, redrawPlacedItems, removeItemFromGrid, placeItem, canPlace } from './inventory.js';
+import { saveInventory } from './storage.js';
+import { showContextMenu, hideContextMenu, openEditModal } from './context-menu.js';
+
+export function showPanelContextMenu(item, e) {
+    const opts = [
+        { label: 'Remover', action: () => removeItemFromPanel(item.id) },
+        { label: 'Editar', action: () => openEditModal(item, updates => {
+                Object.assign(item, updates);
+                updateItemList();
+                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+            }) },
+        { label: 'Girar', action: () => {
+                const tmpW = item.width;
+                item.width = item.height;
+                item.height = tmpW;
+                item.rotacionado = !item.rotacionado;
+                updateItemList();
+                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+            } },
+        { label: 'Add Imagem', action: async () => {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = 'image/*';
+                input.addEventListener('change', async () => {
+                    const img = await readImageFile(input);
+                    if (img) {
+                        item.img = img;
+                        updateItemList();
+                        saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+                    }
+                });
+                input.click();
+            } },
+        { label: 'Remover Imagem', action: () => {
+                item.img = null;
+                updateItemList();
+                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+            } },
+        { label: 'Deletar', action: () => {
+                if (confirm('Tem certeza que deseja excluir este item permanentemente?')) {
+                    removeItemFromPanel(item.id);
+                }
+            } }
+    ];
+    showContextMenu(opts, e.clientX, e.clientY);
+}
+
+export function handleInventoryContextMenu(e) {
+    e.preventDefault();
+    if (!session.isMaster) return;
+    const cell = e.target.closest('.cell');
+    if (!cell || !cell.classList.contains('placed')) {
+        hideContextMenu();
+        return;
+    }
+    const itemId = cell.dataset.itemid;
+    if (!itemId) return;
+    const state = getInventoryState();
+    const placed = state.placedItems.find(it => it.id === itemId);
+    if (!placed) return;
+    hideContextMenu();
+    const opts = [
+        { label: 'Remover', action: () => removeItemFromGrid(itemId, false) },
+        { label: 'Editar', action: () => openEditModal(placed, updates => {
+                Object.assign(placed, updates);
+                redrawPlacedItems();
+                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+            }) },
+        { label: 'Girar', action: () => {
+                const tmpW = placed.width;
+                const tmpH = placed.height;
+                const newItem = { ...placed, width: tmpH, height: tmpW, rotacionado: !placed.rotacionado };
+                removeItemFromGrid(itemId, true);
+                if (canPlace(placed.x, placed.y, newItem.width, newItem.height)) {
+                    placeItem(placed.x, placed.y, newItem.width, newItem.height, newItem);
+                } else {
+                    placeItem(placed.x, placed.y, placed.width, placed.height, placed);
+                    alert('Não há espaço para girar o item.');
+                }
+            } },
+        { label: 'Add Imagem', action: async () => {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = 'image/*';
+                input.addEventListener('change', async () => {
+                    const img = await readImageFile(input);
+                    if (img) {
+                        placed.img = img;
+                        redrawPlacedItems();
+                        saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+                    }
+                });
+                input.click();
+            } },
+        { label: 'Remover Imagem', action: () => {
+                placed.img = null;
+                redrawPlacedItems();
+                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
+            } },
+        { label: 'Deletar', action: () => {
+                if (confirm('Tem certeza que deseja excluir este item permanentemente?')) {
+                    removeItemFromGrid(itemId, true);
+                }
+            } }
+    ];
+    showContextMenu(opts, e.clientX, e.clientY);
+}

--- a/public/js/ghost-preview.js
+++ b/public/js/ghost-preview.js
@@ -1,0 +1,101 @@
+import { inventory, createItemImageElement, canPlace } from './inventory.js';
+import { ROWS, COLS, CELL_GAP, getCellSize } from './constants.js';
+
+let dragGhost;
+let previewRotation = false;
+let currentPreviewSize = { width: 1, height: 1 };
+let lastGhostPos = { x: null, y: null, valid: true };
+
+export function initGhost(el) {
+    dragGhost = el;
+}
+
+export function setPreviewSize(width, height) {
+    currentPreviewSize = { width, height };
+}
+
+export function setPreviewRotation(rot) {
+    previewRotation = rot;
+}
+
+export function getPreviewRotation() {
+    return previewRotation;
+}
+
+export function getCurrentPreviewSize() {
+    return { ...currentPreviewSize };
+}
+
+export function getLastGhostPos() {
+    return { ...lastGhostPos };
+}
+
+export function computeGridPosition(pageX, pageY) {
+    const invRect = inventory.getBoundingClientRect();
+    const relX = pageX - invRect.left;
+    const relY = pageY - invRect.top;
+    const total = getCellSize() + CELL_GAP;
+    let gridX = Math.floor(relX / total);
+    let gridY = Math.floor(relY / total);
+    if (gridX < 0) gridX = 0;
+    if (gridY < 0) gridY = 0;
+    if (gridX > COLS - currentPreviewSize.width) gridX = COLS - currentPreviewSize.width;
+    if (gridY > ROWS - currentPreviewSize.height) gridY = ROWS - currentPreviewSize.height;
+    return { gridX, gridY };
+}
+
+export function snapGhostToGrid(pageX, pageY, draggedItem) {
+    const { gridX, gridY } = computeGridPosition(pageX, pageY);
+    lastGhostPos = { x: gridX, y: gridY };
+    showGhostOnGrid(gridX, gridY, draggedItem);
+}
+
+export function showGhostOnGrid(gridX, gridY, draggedItem) {
+    if (!dragGhost) return;
+    const valid = canPlace(gridX, gridY, currentPreviewSize.width, currentPreviewSize.height);
+    dragGhost.innerHTML = '';
+    const total = getCellSize() + CELL_GAP;
+    dragGhost.style.width = (currentPreviewSize.width * total - CELL_GAP - 2) + 'px';
+    dragGhost.style.height = (currentPreviewSize.height * total - CELL_GAP - 2) + 'px';
+    dragGhost.style.display = 'block';
+    dragGhost.className = valid ? '' : 'ghost-invalid';
+
+    for (let i = 0; i < currentPreviewSize.width * currentPreviewSize.height; i++) {
+        const cell = document.createElement('div');
+        cell.className = 'ghost-cell';
+        dragGhost.appendChild(cell);
+    }
+
+    if (draggedItem && draggedItem.img) {
+        const img = createItemImageElement({ ...draggedItem, rotacionado: previewRotation }, currentPreviewSize.width, currentPreviewSize.height, true);
+        dragGhost.appendChild(img);
+    }
+
+    const invRect = inventory.getBoundingClientRect();
+    dragGhost.style.left = (invRect.left + gridX * total) + 'px';
+    dragGhost.style.top = (invRect.top + gridY * total) + 'px';
+
+    removePreview();
+    if (valid) {
+        for (let dy = 0; dy < currentPreviewSize.height; dy++) {
+            for (let dx = 0; dx < currentPreviewSize.width; dx++) {
+                const index = (gridY + dy) * COLS + (gridX + dx);
+                const c = inventory.children[index];
+                if (c) c.classList.add('preview');
+            }
+        }
+    }
+    lastGhostPos.valid = valid;
+}
+
+export function removePreview() {
+    document.querySelectorAll('.cell.preview').forEach(c => c.classList.remove('preview'));
+}
+
+export function hideGhost() {
+    if (!dragGhost) return;
+    dragGhost.style.display = 'none';
+    dragGhost.innerHTML = '';
+    dragGhost.className = '';
+    lastGhostPos = { x: null, y: null, valid: true };
+}

--- a/public/js/placement.js
+++ b/public/js/placement.js
@@ -1,0 +1,42 @@
+import { placeItem, returnItemToPanel, removeItemFromPanel, updateItemList, getInventoryState } from './inventory.js';
+import { saveInventory } from './storage.js';
+
+export function finalizeMouseDrop(e, params) {
+    const { inventory, lastGhostPos, draggedItem, draggedFromGrid, currentPreviewSize, previewRotation, previousPlacement, hideGhost, removePreview } = params;
+    const invRect = inventory.getBoundingClientRect();
+    const outOfGrid = (
+        e.clientX < invRect.left ||
+        e.clientY < invRect.top ||
+        e.clientX > invRect.right ||
+        e.clientY > invRect.bottom
+    );
+
+    const state = getInventoryState();
+
+    if (outOfGrid && draggedItem) {
+        returnItemToPanel(draggedItem);
+    } else if (lastGhostPos.x !== null && lastGhostPos.y !== null && draggedItem) {
+        if (lastGhostPos.valid) {
+            placeItem(lastGhostPos.x, lastGhostPos.y, currentPreviewSize.width, currentPreviewSize.height, { ...draggedItem, rotacionado: previewRotation });
+        } else if (draggedFromGrid) {
+            placeItem(previousPlacement.x, previousPlacement.y, previousPlacement.width, previousPlacement.height, previousPlacement);
+        }
+    }
+
+    removePreview();
+    hideGhost();
+    saveInventory(state.itemsData, state.placedItems);
+}
+
+export function handlePanelDrop(draggedItem, lastGhostPos, currentPreviewSize, previewRotation, removePreview, hideGhost) {
+    if (!draggedItem) return;
+    if (lastGhostPos.x !== null && lastGhostPos.y !== null && lastGhostPos.valid) {
+        removeItemFromPanel(draggedItem.id);
+        placeItem(lastGhostPos.x, lastGhostPos.y, currentPreviewSize.width, currentPreviewSize.height, { ...draggedItem, rotacionado: previewRotation });
+    }
+    removePreview();
+    hideGhost();
+    const state = getInventoryState();
+    saveInventory(state.itemsData, state.placedItems);
+    updateItemList();
+}


### PR DESCRIPTION
## Summary
- break drag/drop code into smaller helpers
- add ghost preview module
- add placement helper
- centralize context menu logic
- delegate panel item events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_68692082bbac83209f1bde49e96c7d91