### PR TITLE
Handle missing items.json gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,16 @@ You can also set `USERS_FILE_PATH` to change where the `users.json` file is stor
 ### `users.json`
 The file `server/users.json` is created automatically when the server first starts and stores all registered users. Delete this file before launching the server if you wish to reset the credentials.
 
+### Problemas ao carregar scripts ou imagens
+Se ao abrir a página os botões não responderem ou a imagem do personagem estiver ausente, verifique no console do navegador se `inventory-page.js` e `body-ui.js` foram carregados corretamente. Esses arquivos ficam em `public/js/` e devem ser incluídos assim:
+
+```html
+<script type="module" src="js/inventory-page.js"></script>
+<script type="module" src="js/body-ui.js"></script>
+```
+
+Se você salvou os arquivos pelo navegador e eles possuem o sufixo `.download`, renomeie-os para `.js` e recarregue a página. A imagem do personagem será definida automaticamente pelo script.
+
 ### Update items from CSV
 Inside `public/data/` there is a script called `atualizar_items.py` that converts `CSV-itens.csv` into `items.json`. If the `openpyxl` dependency is installed the script will also accept `CSV-itens.xlsx` (not included in the repository). Run:
 

--- a/public/js/storage.js
+++ b/public/js/storage.js
@@ -6,18 +6,24 @@ function generateId() {
 }
 
 async function fetchDefaultItems() {
-    const res = await fetch('data/items.json');
-    const data = await res.json();
-    return data.map(it => ({
-        id: generateId(),
-        nome: it.nome,
-        width: it.width,
-        height: it.height,
-        img: typeof it.img === 'string' && it.img.length ? it.img : null,
-        color: typeof it.color === 'string' ? it.color : '#2b8a3e',
-        maxEstresse: Number.isFinite(it.maxEstresse) ? it.maxEstresse : 3,
-        estresseAtual: Number.isFinite(it.estresseAtual) ? it.estresseAtual : 0
-    }));
+    try {
+        const res = await fetch('data/items.json');
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        const data = await res.json();
+        return data.map(it => ({
+            id: generateId(),
+            nome: it.nome,
+            width: it.width,
+            height: it.height,
+            img: typeof it.img === 'string' && it.img.length ? it.img : null,
+            color: typeof it.color === 'string' ? it.color : '#2b8a3e',
+            maxEstresse: Number.isFinite(it.maxEstresse) ? it.maxEstresse : 3,
+            estresseAtual: Number.isFinite(it.estresseAtual) ? it.estresseAtual : 0
+        }));
+    } catch (e) {
+        console.warn('Could not load items.json, falling back to defaults.', e);
+        return defaultItems();
+    }
 }
 
 function defaultItems() {


### PR DESCRIPTION
## Summary
- avoid crash in `fetchDefaultItems` when `items.json` is missing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68694517f1ac83209d41be3cd08ed23d