### PR TITLE
Adjust attributes layout and body styling

### DIFF
--- a/public/css/character-body.css
+++ b/public/css/character-body.css
@@ -16,6 +16,9 @@
     grid-template-rows: repeat(4, 120px);
     gap: 10px;
     margin: 20px auto;
+    background: url('../img/body.png') no-repeat center center;
+    background-size: contain;
+    position: relative;
 }
 
 #head { grid-column: 2; grid-row: 1; }
@@ -33,6 +36,16 @@
     align-items: center;
     justify-content: center;
     font-size: 0.9rem;
+    background: rgba(0, 255, 0, 0.2);
+}
+
+.body-part .zone-name {
+    position: absolute;
+    top: -1.2em;
+    left: 50%;
+    transform: translateX(-50%);
+    font-weight: bold;
+    text-shadow: 0 0 4px #000;
 }
 
 .stress-indicator {

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -17,6 +17,10 @@
     
     <div id="drag-ghost"></div>
     <h1>Inventário Tetris</h1>
+    <div id="attributes" class="panel">
+        <h2>Atributos</h2>
+        <div id="attr-list" class="attr-list"></div>
+    </div>
     <div id="layout">
         <div id="inventory"></div>
         <div id="character-body" class="panel">
@@ -79,11 +83,6 @@
         </form>
     </div>
 
-    <h1>Ficha Oblívio</h1>
-    <div id="attributes" class="panel">
-        <h2>Atributos</h2>
-        <div id="attr-list" class="attr-list"></div>
-    </div>
     <div id="skills" class="panel">
         <h2>Habilidades</h2>
         <div id="skill-list"></div>

--- a/public/oblivio.html
+++ b/public/oblivio.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
-    <title>Ficha Oblívio</title>
+    <title>Ficha de Magia &amp; Mágica</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/common.css">


### PR DESCRIPTION
## Summary
- reposition attributes panel on inventory page
- remove duplicated "Ficha Oblívio" title
- tweak character body styles to show labels above squares and apply body.png background
- update Oblívio page title

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68697d2badb0832089092d5ac96b7979