### PR TITLE
Atualiza layout da ficha com magias e melhorias visuais

### DIFF
--- a/public/css/character-body.css
+++ b/public/css/character-body.css
@@ -14,9 +14,9 @@
     display: grid;
     grid-template-columns: repeat(3, 120px);
     grid-template-rows: repeat(4, 120px);
-    gap: 10px;
+    gap: 20px;
     margin: 20px auto;
-    background: url('../img/body.png') no-repeat center center;
+    background: url('/img/body.png') no-repeat center center;
     background-size: contain;
     position: relative;
 }

--- a/public/css/oblivio.css
+++ b/public/css/oblivio.css
@@ -1,4 +1,4 @@
-.attr-list, #skill-list {
+.attr-list, #skill-list, #spell-list {
     display: flex;
     flex-direction: column;
     gap: 8px;
@@ -44,4 +44,14 @@
 
 #add-skill {
     margin-top: 10px;
+}
+#add-spell {
+    margin-top: 10px;
+}
+
+#skills-container {
+    display: flex;
+    gap: 20px;
+    justify-content: center;
+    flex-wrap: wrap;
 }

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
     <meta charset="UTF-8">
-    <title>Inventário Tetris</title>
+    <title>Ficha de Magia &amp; Mágica</title>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=UnifrakturCook:wght@700&family=Cinzel+Decorative:wght@400;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/common.css">
@@ -17,10 +17,6 @@
     
     <div id="drag-ghost"></div>
     <h1>Inventário Tetris</h1>
-    <div id="attributes" class="panel">
-        <h2>Atributos</h2>
-        <div id="attr-list" class="attr-list"></div>
-    </div>
     <div id="layout">
         <div id="inventory"></div>
         <div id="character-body" class="panel">
@@ -58,6 +54,10 @@
             </div>
         </div>
     </div>
+    <div id="attributes" class="panel">
+        <h2>Atributos</h2>
+        <div id="attr-list" class="attr-list"></div>
+    </div>
 
     <div id="items" class="panel">
         <div id="side-actions">
@@ -83,10 +83,17 @@
         </form>
     </div>
 
-    <div id="skills" class="panel">
-        <h2>Habilidades</h2>
-        <div id="skill-list"></div>
-        <button id="add-skill" class="btn">Nova habilidade</button>
+    <div id="skills-container">
+        <div id="skills" class="panel">
+            <h2>Habilidades</h2>
+            <div id="skill-list"></div>
+            <button id="add-skill" class="btn">Nova habilidade</button>
+        </div>
+        <div id="spells" class="panel">
+            <h2>Magias Conhecidas</h2>
+            <div id="spell-list"></div>
+            <button id="add-spell" class="btn">Nova magia</button>
+        </div>
     </div>
 
     <script type="module" src="js/inventory.js"></script>

--- a/public/js/body-ui.js
+++ b/public/js/body-ui.js
@@ -1,5 +1,5 @@
 import { getInventoryState } from './inventory.js';
-const BODY_IMG_SRC = 'img/body.png';
+const BODY_IMG_SRC = '/img/body.png';
 
 const MAX_STRESS = 3;
 const parts = [

--- a/public/js/oblivio-page.js
+++ b/public/js/oblivio-page.js
@@ -78,6 +78,37 @@ function addSkill(name = '', type = 'ativa') {
     list.appendChild(div);
 }
 
+function addSpell(name = '', type = 'ativa') {
+    const list = document.getElementById('spell-list');
+    const div = document.createElement('div');
+    div.className = 'skill';
+
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.placeholder = 'Nome';
+    input.value = name;
+
+    const select = document.createElement('select');
+    const optA = document.createElement('option');
+    optA.value = 'ativa';
+    optA.textContent = 'Ativa';
+    const optP = document.createElement('option');
+    optP.value = 'passiva';
+    optP.textContent = 'Passiva';
+    select.append(optA, optP);
+    select.value = type;
+
+    const remove = document.createElement('button');
+    remove.className = 'btn remove';
+    remove.textContent = '✕';
+    remove.addEventListener('click', () => {
+        list.removeChild(div);
+    });
+
+    div.append(input, select, remove);
+    list.appendChild(div);
+}
+
 window.addEventListener('DOMContentLoaded', () => {
     setupThemeToggle();
 
@@ -92,4 +123,8 @@ window.addEventListener('DOMContentLoaded', () => {
     });
 
     document.getElementById('add-skill').addEventListener('click', () => addSkill());
+    const addSpellBtn = document.getElementById('add-spell');
+    if (addSpellBtn) {
+        addSpellBtn.addEventListener('click', () => addSpell());
+    }
 });


### PR DESCRIPTION
## Summary
- move o inventário acima dos atributos
- adiciona painel de **Magias Conhecidas** ao lado de Habilidades
- deixa os dois painéis lado a lado por CSS
- ajusta imagem e espaçamento do diagrama do corpo
- altera título da página para "Ficha de Magia & Mágica"

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6869818f7f0c8320b318ad62bf7b03d2