### PR TITLE
Adjust layout and CSS for Ficha Magia

### DIFF
--- a/public/css/character-body.css
+++ b/public/css/character-body.css
@@ -12,19 +12,21 @@
 
 #body-diagram {
     display: grid;
-    grid-template-columns: repeat(3, 120px);
-    grid-template-rows: repeat(4, 120px);
-    gap: 20px;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    gap: 10px;
     margin: 20px auto;
     background: url('/img/body.png') no-repeat center center;
     background-size: contain;
     position: relative;
+    width: 400px;
+    height: 500px;
 }
 
-#head { grid-column: 2; grid-row: 1; }
+#head { grid-column: 1; grid-row: 1; }
 #left-arm { grid-column: 1; grid-row: 2; }
-#torso { grid-column: 2; grid-row: 2 / span 2; }
 #right-arm { grid-column: 3; grid-row: 2; }
+#torso { grid-column: 2; grid-row: 3; }
 #left-leg { grid-column: 1; grid-row: 4; }
 #right-leg { grid-column: 3; grid-row: 4; }
 

--- a/public/css/oblivio.css
+++ b/public/css/oblivio.css
@@ -1,4 +1,11 @@
-.attr-list, #skill-list, #spell-list {
+.attr-list {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-top: 10px;
+}
+#skill-list,
+#spell-list {
     display: flex;
     flex-direction: column;
     gap: 8px;

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -16,7 +16,11 @@
     <button id="toggle-theme" class="btn">🌙</button>
     
     <div id="drag-ghost"></div>
-    <h1>Inventário Tetris</h1>
+    <h1>Ficha de Magia &amp; Mágica</h1>
+    <div id="attributes" class="panel">
+        <h2>Atributos</h2>
+        <div id="attr-list" class="attr-list"></div>
+    </div>
     <div id="layout">
         <div id="inventory"></div>
         <div id="character-body" class="panel">
@@ -54,11 +58,6 @@
             </div>
         </div>
     </div>
-    <div id="attributes" class="panel">
-        <h2>Atributos</h2>
-        <div id="attr-list" class="attr-list"></div>
-    </div>
-
     <div id="items" class="panel">
         <div id="side-actions">
             <button id="logout-btn" class="btn">Sair</button>


### PR DESCRIPTION
## Summary
- reposition attributes above inventory
- switch page heading to **Ficha de Magia & Mágica**
- show attributes in a three-column grid
- tweak body diagram grid to keep all parts uniform

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_68698f3de76083208db5e3a97619dc57