### PR TITLE
Melhora alinhamento da ficha de inventário

### DIFF
--- a/public/css/character-body.css
+++ b/public/css/character-body.css
@@ -1,8 +1,3 @@
-#layout {
-    display: flex;
-    gap: 40px;
-    align-items: flex-start;
-}
 
 #character-body {
     display: flex;

--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -393,13 +393,42 @@ body.dark-mode #reset-btn {
     justify-content: flex-end;
 }
 
-.habilidades-magias {
+.layout-principal {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+  margin-top: 2rem;
+}
+
+.col-esquerda {
+  flex: 1;
+  max-width: 60%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.col-direita {
+  flex: 1;
+  max-width: 40%;
   display: flex;
   justify-content: center;
-  gap: 2rem;
-  margin-top: 1rem;
-  flex-wrap: wrap;
 }
+
+.atributos, .inventario {
+  margin-bottom: 1rem;
+  text-align: center;
+}
+
+.habilidades-magias {
+  display: flex;
+  gap: 2rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 1rem;
+}
+
 .habilidades, .magias {
   background: #000;
   border: 1px solid #fff;

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -17,16 +17,31 @@
     
     <div id="drag-ghost"></div>
     <h1>Ficha de Magia &amp; Mágica</h1>
-    <div id="attributes" class="panel">
-        <h2>Atributos</h2>
-        <div id="attr-list" class="attr-list"></div>
-    </div>
-    <div id="layout">
-        <div id="inventory"></div>
-        <div id="character-body" class="panel">
-            <div id="body-diagram">
-                <div class="body-part panel" id="head">
-                    <label class="zone-name">Cabeça</label>
+    <div class="layout-principal">
+        <div class="col-esquerda">
+            <div id="attributes" class="panel atributos">
+                <h2>Atributos</h2>
+                <div id="attr-list" class="attr-list"></div>
+            </div>
+            <div id="inventory" class="inventario"></div>
+            <div id="skills-container" class="habilidades-magias">
+                <div id="skills" class="panel habilidades">
+                    <h2>Habilidades</h2>
+                    <div id="skill-list"></div>
+                    <button id="add-skill" class="btn">Nova habilidade</button>
+                </div>
+                <div id="spells" class="panel magias">
+                    <h2>Magias Conhecidas</h2>
+                    <div id="spell-list"></div>
+                    <button id="add-spell" class="btn">Nova magia</button>
+                </div>
+            </div>
+        </div>
+        <div class="col-direita">
+            <div id="character-body" class="panel">
+                <div id="body-diagram">
+                    <div class="body-part panel" id="head">
+                        <label class="zone-name">Cabeça</label>
                     <div class="stress-indicator"><button class="stress-minus btn">-</button><span class="stress-val">0/3</span><button class="stress-plus btn">+</button></div>
                     <div class="equip-space" data-part="head">Espaço para item</div>
                 </div>
@@ -80,19 +95,6 @@
             <input type="color" id="cor" value="#2b8a3e">
             <button type="submit" class="btn">Adicionar</button>
         </form>
-    </div>
-
-    <div id="skills-container" class="habilidades-magias">
-        <div id="skills" class="panel habilidades">
-            <h2>Habilidades</h2>
-            <div id="skill-list"></div>
-            <button id="add-skill" class="btn">Nova habilidade</button>
-        </div>
-        <div id="spells" class="panel magias">
-            <h2>Magias Conhecidas</h2>
-            <div id="spell-list"></div>
-            <button id="add-spell" class="btn">Nova magia</button>
-        </div>
     </div>
 
     <script type="module" src="js/inventory.js"></script>


### PR DESCRIPTION
## Summary
- reestrutura layout do `inventory.html` para separar colunas esquerda e direita
- define estilos em `inventory.css` para `.layout-principal` e colunas
- remove regra antiga `#layout` e mantém apenas regras do diagrama

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6869aea194648320865d727ae948fcd5