### PR TITLE
Fix attributes panel width

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -5,6 +5,7 @@
     height: 100%;
     align-items: center;
     justify-content: center;
+    grid-area: inventory;
 }
 
 #inventory {
@@ -23,9 +24,9 @@
 }
 
 #attributes {
-    width: calc(var(--cols) * var(--cell-size) + (var(--cols) - 1) * var(--cell-gap));
+    width: 100%;
     padding: var(--cell-gap);
-    margin: 0 auto;
+    margin: 0 0 1rem;
     box-sizing: border-box;
 }
 
@@ -487,12 +488,17 @@ body.dark-mode #reset-btn {
     font-family: 'Georgia', serif;
 }
 
-.linha {
-    display: flex;
-    justify-content: space-between;
+#section-grid {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(4, auto);
+    grid-template-areas:
+        "inventory inventory body body"
+        "inventory inventory body body"
+        "skills skills spells spells"
+        "skills skills spells spells";
     gap: 20px;
-    flex-wrap: wrap;
-    margin-bottom: 1rem;
+    width: 100%;
 }
 
 .atributos {
@@ -519,3 +525,7 @@ body.dark-mode #reset-btn {
     width: 100%;
     height: 100%;
 }
+
+.corpo { grid-area: body; }
+.habilidades { grid-area: skills; }
+.magias { grid-area: spells; }

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -19,14 +19,12 @@
     <h1>Ficha de Magia &amp; Mágica</h1>
 
     <div class="ficha-container">
-        <div class="linha atributos">
-            <div id="attributes" class="panel">
-                <h2>Atributos</h2>
-                <div id="attr-list" class="attr-list"></div>
-            </div>
+        <div id="attributes" class="panel">
+            <h2>Atributos</h2>
+            <div id="attr-list" class="attr-list"></div>
         </div>
 
-        <div class="linha">
+        <div id="section-grid">
             <div id="coluna-inventario" class="coluna inventario">
                 <div id="inventory"></div>
                 <div id="resize-panel" class="panel" style="display:none;">
@@ -73,9 +71,7 @@
                     </div>
                 </div>
             </div>
-        </div>
 
-        <div class="linha">
             <div class="coluna habilidades">
                 <div id="skills" class="panel habilidades">
                     <h2>Habilidades</h2>
@@ -91,7 +87,7 @@
                 </div>
             </div>
         </div>
-    </div>
+        </div>
 
     <div id="items" class="panel">
         <div id="side-actions">


### PR DESCRIPTION
## Summary
- adjust `#attributes` styling so borders align to sheet edges
- restructure HTML layout using a column with a grid for rows
- switch main section layout to 4x4 CSS grid so inventory, body, skills, and spells fit in grid areas

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686ab209516c8320a8de81b5697b94ec