### PR TITLE
Add USERS_FILE_PATH alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Pré-requisitos: **Node.js 18+** e **Python 3** caso queira utilizar o script de
 
    A rota `/master-hash` permite consultar o valor da variável de ambiente `MASTER_PASSWORD_HASH`, caso ela esteja definida. Defina essa variável antes de iniciar o servidor se precisar fornecer o hash de uma senha mestre externa.
 
-   Você também pode definir `USERS_FILE_PATH` para alterar o local do arquivo `users.json`. O diretório será criado automaticamente caso não exista.
+  Você também pode definir `USERS_FILE_PATH` (ou o antigo `USERS_FILE`) para alterar o local do arquivo `users.json`. O diretório será criado automaticamente caso não exista.
 
 
 ## 📑 users.json
@@ -223,7 +223,7 @@ fetch('http://localhost:3000/login')
 
 The `/master-hash` endpoint returns the value of the `MASTER_PASSWORD_HASH` environment variable when it is defined. Set this variable before starting the server if you need to provide your own master password hash.
 
-You can also set `USERS_FILE_PATH` to change where the `users.json` file is stored. The folder will be created automatically if it does not exist.
+You can also set `USERS_FILE_PATH` (or the legacy `USERS_FILE`) to change where the `users.json` file is stored. The folder will be created automatically if it does not exist.
 
 ### `users.json`
 The file `server/users.json` is created automatically when the server first starts and stores all registered users. Delete this file before launching the server if you wish to reset the credentials.

--- a/server/storage.js
+++ b/server/storage.js
@@ -2,7 +2,11 @@ const fs = require('fs');
 const path = require('path');
 
 
-const USERS_FILE = process.env.USERS_FILE || path.join(__dirname, 'users.json');
+// Allow both USERS_FILE_PATH and the legacy USERS_FILE variable
+const USERS_FILE =
+  process.env.USERS_FILE_PATH ||
+  process.env.USERS_FILE ||
+  path.join(__dirname, 'users.json');
 
 
 function ensureUsersFile() {


### PR DESCRIPTION
## Summary
- support USERS_FILE_PATH as an environment variable for user data file
- document USERS_FILE_PATH or USERS_FILE in README

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c5c7bca4c83209373676bbb7d3533