### PR TITLE
Remove maxlength limit from item search

### DIFF
--- a/public/inventory.html
+++ b/public/inventory.html
@@ -99,7 +99,7 @@
             <button id="reset-btn" class="btn">Resetar Dados</button>
         </div>
         <h2>Itens</h2>
-        <input id="item-search" type="text" placeholder="Buscar" maxlength="3">
+        <input id="item-search" type="text" placeholder="Buscar">
         <div id="item-list"></div>
         <form id="item-form">
             <h3>Criar Novo Item</h3>


### PR DESCRIPTION
## Summary
- remove maxlength from `item-search` field so users can type longer queries

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_686c5da2145483208c53d857f451637f