### PR TITLE
Enable external address env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Pré-requisitos: **Node.js 18+** e **Python 3** caso queira utilizar o script de
 
    A rota `/master-hash` permite consultar o valor da variável de ambiente `MASTER_PASSWORD_HASH`, caso ela esteja definida. Defina essa variável antes de iniciar o servidor se precisar fornecer o hash de uma senha mestre externa.
 
-  Você também pode definir `USERS_FILE_PATH` (ou o antigo `USERS_FILE`) para alterar o local do arquivo `users.json`. O diretório será criado automaticamente caso não exista.
+   Você também pode definir `USERS_FILE_PATH` (ou o antigo `USERS_FILE`) para alterar o local do arquivo `users.json`. O diretório será criado automaticamente caso não exista.
+   Defina também `EXTERNAL_ADDRESS` caso queira registrar um endereço externo ao iniciar o servidor (por exemplo, `http://seu-ip:3000`).
 
 
 ## 📑 users.json
@@ -224,6 +225,7 @@ fetch('http://localhost:3000/login')
 The `/master-hash` endpoint returns the value of the `MASTER_PASSWORD_HASH` environment variable when it is defined. Set this variable before starting the server if you need to provide your own master password hash.
 
 You can also set `USERS_FILE_PATH` (or the legacy `USERS_FILE`) to change where the `users.json` file is stored. The folder will be created automatically if it does not exist.
+Set `EXTERNAL_ADDRESS` if you want the server to print an external URL when it starts (e.g., `http://your-ip:3000`).
 
 ### `users.json`
 The file `server/users.json` is created automatically when the server first starts and stores all registered users. Delete this file before launching the server if you wish to reset the credentials.

--- a/server.js
+++ b/server.js
@@ -140,9 +140,12 @@ app.get('/master-hash', (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
+const externalAddress = process.env.EXTERNAL_ADDRESS;
 
 // O servidor escuta em '0.0.0.0', permitindo conexões externas (VPN, LAN etc.)
 app.listen(PORT, '0.0.0.0', () => {
   console.log(`✅ Servidor rodando em http://localhost:${PORT}`);
-  console.log(`🌐 Acesse pela rede VPN usando: http://26.219.159.252:${PORT}`);
+  if (externalAddress) {
+    console.log(`🌐 Acesse externamente usando: ${externalAddress}`);
+  }
 });


### PR DESCRIPTION
## Summary
- log optional external address via `EXTERNAL_ADDRESS`
- document new variable in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c5da2f8e88320b3ed1f5e68f27b60