### PR TITLE
Inline message display

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -145,6 +145,11 @@
     margin-top: 5px;
 }
 
+#item-msg {
+    color: red;
+    margin-top: 8px;
+}
+
 #drag-ghost {
     position: fixed;
     pointer-events: none;

--- a/public/css/login.css
+++ b/public/css/login.css
@@ -52,6 +52,11 @@
     margin-top: 10px;
 }
 
+#login-msg, #register-msg {
+    color: limegreen;
+    margin-top: 10px;
+}
+
 #login-screen input {
     font-size: 1.1em;
     margin-bottom: 7px;

--- a/public/inventory.html
+++ b/public/inventory.html
@@ -114,6 +114,7 @@
             <label for="cor">Cor do item</label>
             <input type="color" id="cor" value="#2b8a3e">
             <button type="submit" class="btn">Adicionar</button>
+            <div id="item-msg"></div>
         </form>
     </div>
 

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -9,6 +9,7 @@ export let itemList;
 export let form;
 export let itemsPanel;
 export let searchInput;
+export let itemMsg;
 
 export function cacheDomElements() {
     inventory = document.getElementById('inventory');
@@ -16,6 +17,7 @@ export function cacheDomElements() {
     form = document.getElementById('item-form');
     itemsPanel = document.getElementById('items');
     searchInput = document.getElementById('item-search');
+    itemMsg = document.getElementById('item-msg');
 }
 
 // Automatically cache elements once the DOM is ready so other modules can use
@@ -178,8 +180,9 @@ export function readImageFile(input) {
 
 export async function handleItemSubmit(e) {
     e.preventDefault();
+    if (itemMsg) itemMsg.textContent = '';
     if (!session.isMaster) {
-        alert("Só o mestre pode criar itens.");
+        if (itemMsg) itemMsg.textContent = 'Só o mestre pode criar itens.';
         return;
     }
     const data = getItemFormData();
@@ -187,6 +190,7 @@ export async function handleItemSubmit(e) {
     data.img = await readImageFile(data.imgInput);
     addNewItem(data);
     form.reset();
+    if (itemMsg) itemMsg.textContent = 'Item adicionado com sucesso.';
 }
 
 export function redrawPlacedItems() {

--- a/public/js/login-page.js
+++ b/public/js/login-page.js
@@ -36,11 +36,13 @@ window.addEventListener('DOMContentLoaded', () => {
   const loginUser = document.getElementById('login-user');
   const loginPass = document.getElementById('login-pass');
   const loginErr = document.getElementById('login-err');
+  const loginMsg = document.getElementById('login-msg');
   const forgotBtn = document.getElementById('forgot-pass');
 
   loginForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     loginErr.textContent = '';
+    if (loginMsg) loginMsg.textContent = '';
     const username = loginUser.value.trim();
     const password = loginPass.value;
     if (!username || !password) {
@@ -75,10 +77,12 @@ window.addEventListener('DOMContentLoaded', () => {
   const regPergunta = document.getElementById('register-question');
   const regResposta = document.getElementById('register-answer');
   const regErr = document.getElementById('register-err');
+  const regMsg = document.getElementById('register-msg');
 
   registerForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     regErr.textContent = '';
+    if (regMsg) regMsg.textContent = '';
     const username = regUser.value.trim();
     const password = regPass.value;
     const pergunta = regPergunta.value.trim();
@@ -103,7 +107,7 @@ window.addEventListener('DOMContentLoaded', () => {
         regErr.textContent = result.error || 'Erro no cadastro.';
         return;
       }
-      alert('✅ Cadastro realizado com sucesso! Faça login para continuar.');
+      if (regMsg) regMsg.textContent = '✅ Cadastro realizado com sucesso! Faça login para continuar.';
       regUser.value = '';
       regPass.value = '';
       regPergunta.value = '';
@@ -118,13 +122,15 @@ window.addEventListener('DOMContentLoaded', () => {
 
   forgotBtn.addEventListener('click', async (e) => {
     e.preventDefault();
+    if (loginErr) loginErr.textContent = '';
+    if (loginMsg) loginMsg.textContent = '';
     const username = prompt('Nome de usuário:');
     if (!username) return;
     try {
       const res = await fetch(`/question/${encodeURIComponent(username)}`);
       const data = await res.json();
       if (!res.ok) {
-        alert(data.error || 'Usuário não encontrado ou sem pergunta secreta cadastrada.');
+        loginErr.textContent = data.error || 'Usuário não encontrado ou sem pergunta secreta cadastrada.';
         return;
       }
       const question = data.pergunta;
@@ -139,13 +145,13 @@ window.addEventListener('DOMContentLoaded', () => {
       });
       const resetResult = await res2.json();
       if (!res2.ok) {
-        alert(resetResult.error || 'Não foi possível redefinir a senha.');
+        loginErr.textContent = resetResult.error || 'Não foi possível redefinir a senha.';
       } else {
-        alert('Senha redefinida com sucesso! Faça login com sua nova senha.');
+        if (loginMsg) loginMsg.textContent = 'Senha redefinida com sucesso! Faça login com sua nova senha.';
       }
     } catch (err) {
       console.error(err);
-      alert('Erro ao tentar recuperar senha.');
+      loginErr.textContent = 'Erro ao tentar recuperar senha.';
     }
   });
 

--- a/public/login.html
+++ b/public/login.html
@@ -29,6 +29,7 @@
                 <a href="#" id="forgot-pass">Esqueci minha senha</a>
                 <a href="#" id="goto-register">Cadastrar</a>
                 <div id="login-err"></div>
+                <div id="login-msg" class="form-msg"></div>
             </form>
         </div>
         <div id="register-box" class="panel" style="display:none;">
@@ -44,6 +45,7 @@
                 <button id="register-btn" class="btn" type="submit">Cadastrar</button>
                 <a href="#" id="goto-login">Já tenho conta</a>
                 <div id="register-err"></div>
+                <div id="register-msg" class="form-msg"></div>
             </form>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add feedback containers to login and inventory pages
- style new message placeholders
- show registration and password recovery results inline
- show item creation errors inline

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c5da044948320a005e75d9f2c0df5