### PR TITLE
Fix item dimension updates

### DIFF
--- a/public/js/context-handlers.js
+++ b/public/js/context-handlers.js
@@ -65,6 +65,8 @@ export function handleInventoryContextMenu(e) {
         { label: 'Remover', action: () => removeItemFromGrid(itemId, false) },
         { label: 'Editar', action: () => openEditModal(placed, updates => {
                 Object.assign(placed, updates);
+                placed.originalWidth = placed.rotacionado ? updates.height : updates.width;
+                placed.originalHeight = placed.rotacionado ? updates.width : updates.height;
                 redrawPlacedItems();
                 saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
             }) },


### PR DESCRIPTION
## Summary
- keep a placed item's original dimensions when edited so returning to the panel works

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c66e309f08320b13a173008456a3c