### PR TITLE
Refactor inventory list rendering and saving

### DIFF
--- a/public/js/context-handlers.js
+++ b/public/js/context-handlers.js
@@ -1,6 +1,5 @@
 import { session } from './login.js';
 import { removeItemFromPanel, updateItemList, readImageFile, getInventoryState, redrawPlacedItems, removeItemFromGrid, placeItem, canPlace } from './inventory.js';
-import { saveInventory } from './storage.js';
 import { showContextMenu, hideContextMenu, openEditModal } from './context-menu.js';
 
 export function showPanelContextMenu(item, e) {
@@ -9,7 +8,6 @@ export function showPanelContextMenu(item, e) {
         { label: 'Editar', action: () => openEditModal(item, updates => {
                 Object.assign(item, updates);
                 updateItemList();
-                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
             }) },
         { label: 'Girar', action: () => {
                 const tmpW = item.width;
@@ -17,7 +15,6 @@ export function showPanelContextMenu(item, e) {
                 item.height = tmpW;
                 item.rotacionado = !item.rotacionado;
                 updateItemList();
-                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
             } },
         { label: 'Add Imagem', action: async () => {
                 const input = document.createElement('input');
@@ -28,7 +25,6 @@ export function showPanelContextMenu(item, e) {
                     if (img) {
                         item.img = img;
                         updateItemList();
-                        saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
                     }
                 });
                 input.click();
@@ -36,7 +32,6 @@ export function showPanelContextMenu(item, e) {
         { label: 'Remover Imagem', action: () => {
                 item.img = null;
                 updateItemList();
-                saveInventory(getInventoryState().itemsData, getInventoryState().placedItems);
             } },
         { label: 'Deletar', action: () => {
                 if (confirm('Tem certeza que deseja excluir este item permanentemente?')) {

--- a/public/js/dragdrop.js
+++ b/public/js/dragdrop.js
@@ -209,7 +209,6 @@ function onDrop(e) {
     if (draggedFromGrid) return;
     handlePanelDrop(draggedItem, getLastGhostPos(), getCurrentPreviewSize(), getPreviewRotation(), removePreview, hideGhost);
     draggedItem = null;
-    updateItemList();
 }
 
 

--- a/public/js/inventory-page.js
+++ b/public/js/inventory-page.js
@@ -1,5 +1,5 @@
 import { session, loadSession, clearSession } from './login.js';
-import { cacheDomElements, initInventory, form, searchInput, updateItemList, redrawPlacedItems, createGrid, inventory, getInventoryState } from './inventory.js';
+import { cacheDomElements, initInventory, form, searchInput, renderItemList, updateItemList, redrawPlacedItems, createGrid, inventory, getInventoryState } from './inventory.js';
 import { handleItemSubmit } from './inventory.js';
 import { initDragDrop, registerPanelDragHandlers } from './dragdrop.js';
 import { applyLayoutSettings, calcDefaultSize, setInventorySize } from './constants.js';
@@ -55,7 +55,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     await initInventory();
     if (searchInput) {
         searchInput.addEventListener('input', () => {
-            updateItemList();
+            renderItemList();
         });
     }
     initDragDrop();

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -49,7 +49,7 @@ export async function initInventory() {
     createGrid();
     itemsData = loaded.itemsData;
     placedItems = loaded.placedItems;
-    updateItemList();
+    renderItemList();
     redrawPlacedItems();
 }
 
@@ -65,7 +65,7 @@ export function createGrid() {
     }
 }
 
-export function updateItemList() {
+export function renderItemList() {
     const query = searchInput ? searchInput.value.toLowerCase() : '';
     itemList.innerHTML = '';
     itemsData
@@ -116,8 +116,12 @@ export function updateItemList() {
 
             itemList.appendChild(el);
         });
-    saveInventory(itemsData, placedItems);
     document.dispatchEvent(new Event('itemListUpdated'));
+}
+
+export function updateItemList() {
+    renderItemList();
+    saveInventory(itemsData, placedItems);
 }
 
 export function getItemFormData() {
@@ -142,13 +146,11 @@ export function addNewItem(data) {
         estresseAtual: 0
     });
     updateItemList();
-    saveInventory(itemsData, placedItems);
 }
 
 export function removeItemFromPanel(itemId) {
     itemsData = itemsData.filter(item => item.id !== itemId);
     updateItemList();
-    saveInventory(itemsData, placedItems);
 }
 
 export function returnItemToPanel(item) {
@@ -163,7 +165,6 @@ export function returnItemToPanel(item) {
         estresseAtual: item.estresseAtual ?? 0
     });
     updateItemList();
-    saveInventory(itemsData, placedItems);
 }
 
 export function readImageFile(input) {
@@ -212,8 +213,9 @@ export function removeItemFromGrid(itemId, isDeleteKey = false) {
 
     if (!isDeleteKey) {
         returnItemToPanel(placed);
+    } else {
+        saveInventory(itemsData, placedItems);
     }
-    saveInventory(itemsData, placedItems);
 }
 
 export function clearCells(x, y, w, h) {

--- a/public/js/placement.js
+++ b/public/js/placement.js
@@ -1,5 +1,4 @@
-import { placeItem, returnItemToPanel, removeItemFromPanel, updateItemList, getInventoryState } from './inventory.js';
-import { saveInventory } from './storage.js';
+import { placeItem, returnItemToPanel, removeItemFromPanel, updateItemList } from './inventory.js';
 
 export function finalizeMouseDrop(e, params) {
     const { inventory, lastGhostPos, draggedItem, draggedFromGrid, currentPreviewSize, previewRotation, previousPlacement, hideGhost, removePreview } = params;
@@ -10,8 +9,6 @@ export function finalizeMouseDrop(e, params) {
         e.clientX > invRect.right ||
         e.clientY > invRect.bottom
     );
-
-    const state = getInventoryState();
 
     if (outOfGrid && draggedItem) {
         returnItemToPanel(draggedItem);
@@ -25,7 +22,6 @@ export function finalizeMouseDrop(e, params) {
 
     removePreview();
     hideGhost();
-    saveInventory(state.itemsData, state.placedItems);
 }
 
 export function handlePanelDrop(draggedItem, lastGhostPos, currentPreviewSize, previewRotation, removePreview, hideGhost) {
@@ -36,7 +32,5 @@ export function handlePanelDrop(draggedItem, lastGhostPos, currentPreviewSize, p
     }
     removePreview();
     hideGhost();
-    const state = getInventoryState();
-    saveInventory(state.itemsData, state.placedItems);
     updateItemList();
 }


### PR DESCRIPTION
## Summary
- add new `renderItemList` renderer and adjust `updateItemList`
- re-render item list on search without persisting
- save inventory directly from item operations
- drop redundant save calls during drag and placement

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c66e5ee2483208393de8ec9057154