### PR TITLE
Fix rotation sync for placed items

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -296,8 +296,8 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             rotacionado: item.rotacionado,
             img: item.img || null,
             color: item.color,
-            originalWidth: item.originalWidth ?? (item.rotacionado ? item.height : item.width),
-            originalHeight: item.originalHeight ?? (item.rotacionado ? item.width : item.height),
+            originalWidth: item.originalWidth ?? item.width,
+            originalHeight: item.originalHeight ?? item.height,
             maxEstresse: item.maxEstresse ?? 3,
             estresseAtual: item.estresseAtual ?? 0
         });


### PR DESCRIPTION
## Summary
- keep placed item original dimensions independent of rotation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c6f080fb48320ad2fe2b554f1ccb7