### PR TITLE
Improve item rotation handling

### DIFF
--- a/public/js/dragdrop.js
+++ b/public/js/dragdrop.js
@@ -31,7 +31,7 @@ export function registerPanelDragHandlers() {
         const item = itemsData[idx];
         hidePanelDeleteButton();
         draggedItem = { ...item, source: 'panel' };
-        setPreviewRotation(false);
+        setPreviewRotation(item.rotacionado);
         setPreviewSize(item.width, item.height);
         setTimeout(() => el.style.opacity = 0.5, 0);
         try { e.dataTransfer.setData('text/plain', item.id); } catch {}
@@ -96,10 +96,13 @@ function onKeyDown(e) {
     if (e.key.toLowerCase() === 'r') {
         const rotation = !getPreviewRotation();
         setPreviewRotation(rotation);
+
+        const swap = rotation !== draggedItem.rotacionado;
         const size = {
-            width: rotation ? draggedItem.height : draggedItem.width,
-            height: rotation ? draggedItem.width : draggedItem.height
+            width: swap ? draggedItem.height : draggedItem.width,
+            height: swap ? draggedItem.width : draggedItem.height
         };
+
         setPreviewSize(size.width, size.height);
         const pos = getLastGhostPos();
         if (pos.x !== null && pos.y !== null) {

--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -296,8 +296,8 @@ export function placeItem(x, y, w, h, item, fromRedraw = false) {
             rotacionado: item.rotacionado,
             img: item.img || null,
             color: item.color,
-            originalWidth: item.originalWidth ?? (item.rotacionado ? item.height : item.width),
-            originalHeight: item.originalHeight ?? (item.rotacionado ? item.width : item.height),
+            originalWidth: item.originalWidth ?? item.width,
+            originalHeight: item.originalHeight ?? item.height,
             maxEstresse: item.maxEstresse ?? 3,
             estresseAtual: item.estresseAtual ?? 0
         });


### PR DESCRIPTION
## Summary
- sync ghost rotation with panel items
- correct item size switching when rotating while dragging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686c6f080fb48320ad2fe2b554f1ccb7