### PR TITLE
Fix image rotation

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -243,6 +243,13 @@
 }
 
 .rotacionado {
+    /* Quando rotacionado, apenas a imagem interna gira. */
+}
+
+/* Aplica a rotação apenas na imagem para manter a caixa externa
+   com as dimensões corretas após o giro. */
+.rotacionado > img,
+.rotacionado .grid-item-img {
     transform: rotate(90deg);
     transform-origin: top left;
 }


### PR DESCRIPTION
## Summary
- fix item image rotation by only rotating the inner image when the element has the `rotacionado` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c79f7816c8320afba23280fd985bb