### PR TITLE
Fix rotated item images

### DIFF
--- a/public/js/inventory.js
+++ b/public/js/inventory.js
@@ -331,12 +331,13 @@ export function createItemImageElement(item, width, height, isGhost = false) {
             canvas.width = pxW;
             canvas.height = pxH;
             const ctx = canvas.getContext('2d');
-            const cx = pxW / 2;
-            const cy = pxH / 2;
+            const scale = Math.min(pxW / img.height, pxH / img.width);
+            const drawW = img.height * scale;
+            const drawH = img.width * scale;
             ctx.save();
-            ctx.translate(cx, cy);
+            ctx.translate(pxW / 2, pxH / 2);
             ctx.rotate(Math.PI / 2);
-            ctx.drawImage(img, -pxH / 2, -pxW / 2, pxH, pxW);
+            ctx.drawImage(img, -drawW / 2, -drawH / 2, drawW, drawH);
             ctx.restore();
         };
     } else {


### PR DESCRIPTION
## Summary
- preserve aspect ratio when drawing rotated item images

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_686c84deb4e48320b0e3fd8c07b8d87a