### PR TITLE
Fix image overflow at grid bottom

### DIFF
--- a/public/css/inventory.css
+++ b/public/css/inventory.css
@@ -10,6 +10,8 @@
     position: relative;
     box-sizing: border-box;
     visibility: visible;
+    /* Impede que imagens de itens vazem para fora do grid */
+    overflow: hidden;
 }
 
 #inventory-grid {


### PR DESCRIPTION
## Summary
- ensure the grid container hides overflow so item images cannot extend beyond its bounds

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_686c881d939483209ca0554995b3c8b8