### PR TITLE
Implement dragging for equipped items

### DIFF
--- a/public/js/body-ui.js
+++ b/public/js/body-ui.js
@@ -1,4 +1,13 @@
-import { getInventoryState, removeItemFromGrid, removeItemFromPanel, adjustItemStress } from './inventory.js';
+import {
+    getInventoryState,
+    removeItemFromGrid,
+    removeItemFromPanel,
+    adjustItemStress,
+    returnItemToPanel,
+    placeItem,
+    inventory,
+    itemList
+} from './inventory.js';
 const BODY_IMG_SRC = '/img/body.png';
 const parts = [
     { id: 'head', name: 'Cabeça' },
@@ -8,6 +17,8 @@ const parts = [
     { id: 'right-leg', name: 'Perna Direita' },
     { id: 'left-leg', name: 'Perna Esquerda' }
 ];
+
+let draggedSlot = null;
 
 function colorFor(current, max) {
     const colors = ['#2b8a3e', '#f1c40f', '#fd7e14', '#c92a2a'];
@@ -34,17 +45,22 @@ window.addEventListener('DOMContentLoaded', () => {
             if (!id) {
                 span.textContent = '0/0';
                 el.style.backgroundColor = colorFor(0, 0);
+                space.draggable = false;
                 return;
             }
             const state = getInventoryState();
-            const item = state.itemsData.find(it => it.id === id) || state.placedItems.find(it => it.id === id);
+            const item = state.itemsData.find(it => it.id === id) ||
+                state.placedItems.find(it => it.id === id) ||
+                space._itemData;
             if (!item) {
                 span.textContent = '0/0';
                 el.style.backgroundColor = colorFor(0, 0);
+                space.draggable = false;
                 return;
             }
             span.textContent = `${item.estresseAtual}/${item.maxEstresse}`;
             el.style.backgroundColor = colorFor(item.estresseAtual, item.maxEstresse);
+            space.draggable = true;
         };
 
         if (plus) plus.addEventListener('click', () => {
@@ -63,6 +79,17 @@ window.addEventListener('DOMContentLoaded', () => {
 
         space.addEventListener('dragover', e => {
             e.preventDefault();
+        });
+        space.addEventListener('dragstart', e => {
+            if (!space.dataset.itemId) {
+                e.preventDefault();
+                return;
+            }
+            draggedSlot = { el: space, update: updateSlotDisplay, span };
+            try { e.dataTransfer.setData('text/plain', space.dataset.itemId); } catch {}
+        });
+        space.addEventListener('dragend', () => {
+            draggedSlot = null;
         });
         space.addEventListener('drop', e => {
             e.preventDefault();
@@ -90,7 +117,49 @@ window.addEventListener('DOMContentLoaded', () => {
                 space.textContent = item.nome;
             }
             space.dataset.itemId = item.id;
+            space._itemData = { ...item };
             updateSlotDisplay(item.id);
         });
     });
+
+    if (inventory) {
+        inventory.addEventListener('dragover', e => {
+            if (draggedSlot) e.preventDefault();
+        });
+        inventory.addEventListener('drop', e => {
+            if (!draggedSlot) return;
+            e.preventDefault();
+            const cell = e.target.closest('.cell');
+            if (!cell) return;
+            const x = parseInt(cell.dataset.x, 10);
+            const y = parseInt(cell.dataset.y, 10);
+            const item = draggedSlot.el._itemData;
+            if (!item) return;
+            placeItem(x, y, item.width, item.height, item);
+            draggedSlot.el.innerHTML = 'Espaço para item';
+            delete draggedSlot.el.dataset.itemId;
+            delete draggedSlot.el._itemData;
+            draggedSlot.update(null);
+            draggedSlot = null;
+        });
+    }
+
+    if (itemList) {
+        itemList.addEventListener('dragover', e => {
+            if (draggedSlot) e.preventDefault();
+        });
+        itemList.addEventListener('drop', e => {
+            if (!draggedSlot) return;
+            e.preventDefault();
+            const item = draggedSlot.el._itemData;
+            if (!item) return;
+            returnItemToPanel(item);
+            draggedSlot.el.innerHTML = 'Espaço para item';
+            delete draggedSlot.el.dataset.itemId;
+            delete draggedSlot.el._itemData;
+            draggedSlot.update(null);
+            draggedSlot = null;
+        });
+    }
 });
+


### PR DESCRIPTION
## Summary
- allow dragging items out of character equipment slots
- remove images/text when moving items to the grid or the panel
- return or place items accordingly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_68803fc5eeec832096167ce1e174ecc2