### PR TITLE
Fix drag drop return logic

### DIFF
--- a/public/js/placement.js
+++ b/public/js/placement.js
@@ -10,7 +10,7 @@ export function finalizeMouseDrop(e, params) {
         e.clientY > invRect.bottom
     );
 
-    if (outOfGrid && draggedItem) {
+    if (outOfGrid && draggedItem && draggedFromGrid) {
         returnItemToPanel(draggedItem);
     } else if (lastGhostPos.x !== null && lastGhostPos.y !== null && draggedItem) {
         if (lastGhostPos.valid) {


### PR DESCRIPTION
## Summary
- fix finalizeMouseDrop to only return items to the panel when the drag originated from the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6880478ad1448320b785c64c52895a92