### PR TITLE
Clarify items.json generation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Abra `http://localhost:3000/login.html` (ou `index.html`) no navegador para aces
 O arquivo `server/users.json` é gerado automaticamente na primeira execução do servidor e armazena os usuários cadastrados. Se quiser reiniciar os cadastros, exclua esse arquivo antes de iniciar o servidor.
 
 ### Atualizar itens via CSV
-Na pasta `public/data/` existe o script `atualizar_items.py` que converte o arquivo `CSV-itens.csv` em `items.json`. Caso tenha a dependência `openpyxl` instalada, o script também aceita `CSV-itens.xlsx` (não incluído no repositório). Execute:
+Na pasta `public/data/` existe o script `atualizar_items.py` que converte o arquivo `CSV-itens.csv` em `items.json`. O arquivo `items.json` vem vazio no repositório e precisa ser gerado uma primeira vez com o script. Caso tenha a dependência `openpyxl` instalada, o script também aceita `CSV-itens.xlsx` (não incluído no repositório). Execute:
 
 ```bash
 python3 public/data/atualizar_items.py
@@ -251,7 +251,7 @@ Se ao abrir a página os botões não responderem ou a imagem do personagem esti
 Se você salvou os arquivos pelo navegador e eles possuem o sufixo `.download`, renomeie-os para `.js` e recarregue a página. A imagem do personagem será definida automaticamente pelo script.
 
 ### Update items from CSV
-Inside `public/data/` there is a script called `atualizar_items.py` that converts `CSV-itens.csv` into `items.json`. If the `openpyxl` dependency is installed the script will also accept `CSV-itens.xlsx` (not included in the repository). Run:
+Inside `public/data/` there is a script called `atualizar_items.py` that converts `CSV-itens.csv` into `items.json`. The repository ships with an empty `items.json`, so run the script once to create it. If the `openpyxl` dependency is installed the script will also accept `CSV-itens.xlsx` (not included in the repository). Run:
 
 ```bash
 python3 public/data/atualizar_items.py


### PR DESCRIPTION
## Summary
- explain that `items.json` starts empty
- instruct users to generate it via `python3 public/data/atualizar_items.py`

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68813c58f00883209e9b60c89e6e3b92